### PR TITLE
Filter NaN values before registration

### DIFF
--- a/cpp/examples/src/run_kiss_matcher.cc
+++ b/cpp/examples/src/run_kiss_matcher.cc
@@ -3,6 +3,7 @@
 #include <kiss_matcher/FasterPFH.hpp>
 #include <kiss_matcher/GncSolver.hpp>
 #include <kiss_matcher/KISSMatcher.hpp>
+#include <pcl/filters/filter.h>
 #include <pcl/io/pcd_io.h>
 
 #include "quatro/quatro_utils.h"
@@ -44,6 +45,11 @@ int main(int argc, char** argv) {
   std::cout << "Target input: " << tgt_path << "\n";
   int src_load_result = pcl::io::loadPCDFile<pcl::PointXYZ>(src_path, *src_pcl);
   int tgt_load_result = pcl::io::loadPCDFile<pcl::PointXYZ>(tgt_path, *tgt_pcl);
+
+  std::vector<int> indices_src;
+  std::vector<int> indices_tgt;
+  pcl::removeNaNFromPointCloud(*src_pcl, *src_pcl, indices_src);
+  pcl::removeNaNFromPointCloud(*tgt_pcl, *tgt_pcl, indices_tgt);
 
   pcl::PointCloud<pcl::PointXYZ>::Ptr rotated_src_pcl(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::transformPointCloud(*src_pcl, *rotated_src_pcl, yaw_transform);


### PR DESCRIPTION
Hi, thanks for the great work! This is just a very quick PR.

When running the cpp example on custom data it might happen that NaN points are present, and this makes the voxelization function unhappy:

![image](https://github.com/user-attachments/assets/7ad972a5-b1fd-4de0-8473-3fc1bb4b6d9b)

I just added a filtering step before the registration.

