### PR TITLE
Added function for receiving final inliers

### DIFF
--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -150,6 +150,10 @@ class KISSMatcher {
     return robin_matching_->getFinalCorrespondences();
   }
 
+  std::pair<int, int> getFinalInliers(){
+    return std::make_pair(solver_->getTranslationInliers().size(), solver_->getRotationInliers().size());
+  }
+
   void clear() {
     src_keypoints_.clear();
     tgt_keypoints_.clear();


### PR DESCRIPTION
Adds a simple getter function for receiving the final inliers of the solver as a std::pair in the format (translation, rotation).