### PR TITLE
Feature/usability in backend

### DIFF
--- a/cpp/examples/src/run_kiss_matcher.cc
+++ b/cpp/examples/src/run_kiss_matcher.cc
@@ -90,6 +90,20 @@ int main(int argc, char** argv) {
 
   matcher.print();
 
+  size_t num_rot_inliers = matcher.getNumRotationInliers();
+  size_t num_final_inliers = matcher.getNumFinalInliers();
+
+  // NOTE(hlim): By checking the final inliers, we can determine whether 
+  // the registration was successful or not. The larger the threshold,
+  // the more conservatively the decision is made.
+  // See https://github.com/MIT-SPARK/KISS-Matcher/issues/24
+  size_t thres_num_inliers = 5;
+  if (num_final_inliers < thres_num_inliers) {
+    std::cout << "\033[1;33m=> Registration might have failed :(\033[0m\n";
+  } else {
+    std::cout << "\033[1;32m=> Registration likely succeeded XD\033[0m\n";
+  }
+
   std::cout << solution_eigen << std::endl;
   std::cout << "=====================================" << std::endl;
   pcl::transformPointCloud(src_viz, est_viz, solution_eigen);

--- a/cpp/examples/src/run_kiss_matcher.cc
+++ b/cpp/examples/src/run_kiss_matcher.cc
@@ -106,19 +106,22 @@ int main(int argc, char** argv) {
 
   std::cout << solution_eigen << std::endl;
   std::cout << "=====================================" << std::endl;
-  pcl::transformPointCloud(src_viz, est_viz, solution_eigen);
 
+  // ------------------------------------------------------------
+  // Save warped source cloud
+  // ------------------------------------------------------------
   pcl::PointCloud<pcl::PointXYZ>::Ptr est_cloud(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::transformPointCloud(*src_pcl, *est_cloud, solution_eigen);
-
-  // Save warped source cloud
   std::filesystem::path src_file_path(src_path);
   std::string warped_pcd_filename =
       src_file_path.parent_path().string() + "/" + src_file_path.stem().string() + "_warped.pcd";
   pcl::io::savePCDFileASCII(warped_pcd_filename, *est_cloud);
   std::cout << "Saved transformed source point cloud to: " << warped_pcd_filename << std::endl;
 
+  // ------------------------------------------------------------
   // Visualization
+  // ------------------------------------------------------------
+  pcl::transformPointCloud(src_viz, est_viz, solution_eigen);
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr src_colored(new pcl::PointCloud<pcl::PointXYZRGB>);
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr tgt_colored(new pcl::PointCloud<pcl::PointXYZRGB>);
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr est_q_colored(new pcl::PointCloud<pcl::PointXYZRGB>);

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
@@ -54,17 +54,17 @@ kiss_matcher::KeypointPair KISSMatcher::match(const std::vector<Eigen::Vector3f>
 
   auto t_init = std::chrono::high_resolution_clock::now();
 
-  const auto &src_input = processInput(src_voxelized);
-  const auto &tgt_input = processInput(tgt_voxelized);
+  src_processed_ = std::move(processInput(src));
+  tgt_processed_ = std::move(processInput(tgt));
 
   auto t_process = std::chrono::high_resolution_clock::now();
 
-  faster_pfh_->setInputCloud(src_input);
+  faster_pfh_->setInputCloud(src_processed_);
   // Note(hlim) Some erroneous points are filtered out
   // Thus, # of `src_keypoints_` <= `src_voxelized`
   faster_pfh_->ComputeFeature(src_keypoints_, src_descriptors_);
 
-  faster_pfh_->setInputCloud(tgt_input);
+  faster_pfh_->setInputCloud(tgt_processed_);
   // Note(hlim) Some erroneous points are filtered out
   // Thus, # of `tgt_keypoints_` <= `tgt_voxelized`
   faster_pfh_->ComputeFeature(tgt_keypoints_, tgt_descriptors_);

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
@@ -42,8 +42,8 @@ void KISSMatcher::resetSolver() {
   solver_ = std::make_unique<RobustRegistrationSolver>(params);
 }
 
-kiss_matcher::KeypointPair KISSMatcher::match(const std::vector<Eigen::Vector3f> &src_voxelized,
-                                              const std::vector<Eigen::Vector3f> &tgt_voxelized) {
+kiss_matcher::KeypointPair KISSMatcher::match(const std::vector<Eigen::Vector3f> &src,
+                                              const std::vector<Eigen::Vector3f> &tgt) {
   clear();
   auto processInput = [&](const std::vector<Eigen::Vector3f> &input_cloud) {
     if (config_.use_voxel_sampling_) {
@@ -100,17 +100,19 @@ kiss_matcher::KeypointPair KISSMatcher::match(const std::vector<Eigen::Vector3f>
 }
 
 kiss_matcher::KeypointPair KISSMatcher::match(
-    const Eigen::Matrix<double, 3, Eigen::Dynamic> &src_voxelized,
-    const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt_voxelized) {
-  std::vector<Eigen::Vector3f> src_voxelized_vec(src_voxelized.cols());
-  std::vector<Eigen::Vector3f> tgt_voxelized_vec(tgt_voxelized.cols());
+    const Eigen::Matrix<double, 3, Eigen::Dynamic> &src,
+    const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt) {
+  std::vector<Eigen::Vector3f> src_vec(src.cols());
+  std::vector<Eigen::Vector3f> tgt_vec(tgt.cols());
 
-  for (int i = 0; i < src_voxelized.cols(); ++i) {
-    src_voxelized_vec[i] = src_voxelized.col(i).cast<float>();
-    tgt_voxelized_vec[i] = tgt_voxelized.col(i).cast<float>();
+  for (size_t i = 0; i < src.cols(); ++i) {
+    src_vec[i] = src.col(i).cast<float>();
+  }
+  for (size_t i = 0; i < tgt.cols(); ++i) {
+    tgt_vec[i] = tgt.col(i).cast<float>();
   }
 
-  return match(src_voxelized_vec, tgt_voxelized_vec);
+  return match(src_vec, tgt_vec);
 }
 
 kiss_matcher::RegistrationSolution KISSMatcher::estimate(const std::vector<Eigen::Vector3f> &src,
@@ -141,30 +143,6 @@ kiss_matcher::RegistrationSolution KISSMatcher::estimate(const std::vector<Eigen
   solver_time_ = std::chrono::duration_cast<std::chrono::duration<double>>(t_end - t_start).count();
 
   return solver_->getSolution();
-}
-
-// Note that those are just filtered point cloud
-kiss_matcher::KeypointPair KISSMatcher::getKeypointsFromFasterPFH() {
-  return {src_keypoints_, tgt_keypoints_};
-}
-
-// Note that it should be called after `match` function
-kiss_matcher::KeypointPair KISSMatcher::getKeypointsFromInitialMatching() {
-  const auto &corr = getInitialCorrespondences();
-
-  std::vector<Eigen::Vector3f> src_matched;
-  std::vector<Eigen::Vector3f> tgt_matched;
-
-  src_matched.resize(corr.size());
-  tgt_matched.resize(corr.size());
-
-  for (size_t i = 0; i < corr.size(); ++i) {
-    auto src_idx   = std::get<0>(corr[i]);
-    auto dst_idx   = std::get<1>(corr[i]);
-    src_matched[i] = src_keypoints_[src_idx];
-    tgt_matched[i] = tgt_keypoints_[dst_idx];
-  }
-  return {src_matched, tgt_matched};
 }
 
 double KISSMatcher::getProcessingTime() { return processing_time_; }

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -117,39 +117,100 @@ struct KISSMatcherConfig {
 
 class KISSMatcher {
  public:
+  /**
+   * @brief Constructor that initializes KISSMatcher with a voxel size.
+   * @param voxel_size Size of the voxel grid used for setting other parameters.
+   */
   explicit KISSMatcher(const float &voxel_size);
 
+  /**
+   * @brief Constructor that initializes KISSMatcher with a configuration object.
+   * @param config Configuration parameters for the matcher.
+   */
   explicit KISSMatcher(const KISSMatcherConfig &config);
 
+  /**
+   * @brief reset function
+   */
   void reset();
 
+  /**
+   * @brief Resets the solver, used before pose estimation.
+   * @note This function should call before pose estimation.
+   */
   void resetSolver();
 
-  KeypointPair match(const std::vector<Eigen::Vector3f> &src_voxelized,
-                     const std::vector<Eigen::Vector3f> &tgt_voxelized);
+  /**
+   * @brief Matches keypoints between source and target voxelized point clouds.
+   * @param src Source point cloud.
+   * @note Input clouds are automatically voxelized depending on `config_.use_voxel_sampling_`
+   * @param tgt Target point cloud.
+   * @return A pair of matched keypoints.
+   */
+  KeypointPair match(const std::vector<Eigen::Vector3f> &src,
+                     const std::vector<Eigen::Vector3f> &tgt);
 
-  KeypointPair match(const Eigen::Matrix<double, 3, Eigen::Dynamic> &src_voxelized,
-                     const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt_voxelized);
+  /**
+   * @brief Matches keypoints between source and target voxelized point clouds (Eigen format).
+   * @param src Source point cloud in Eigen format.
+   * @param tgt Target point cloud in Eigen format.
+   * @return A pair of matched keypoints.
+   */
+  KeypointPair match(const Eigen::Matrix<double, 3, Eigen::Dynamic> &src,
+                     const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt);
 
+  /**
+   * @brief Estimates the transformation between source and target point clouds.
+   * @param src Source point cloud.
+   * @param dst Target point cloud.
+   * @return The estimated registration solution.
+   */
   RegistrationSolution estimate(const std::vector<Eigen::Vector3f> &src,
                                 const std::vector<Eigen::Vector3f> &dst);
 
+  /**
+   * @brief Retrieves keypoints detected from FasterPFH.
+   * @return A pair of keypoints from FasterPFH.
+   */
   KeypointPair getKeypointsFromFasterPFH();
 
+  /**
+   * @brief Retrieves keypoints from the initial matching stage.
+   * @return A pair of initially matched keypoints.
+   */
   KeypointPair getKeypointsFromInitialMatching();
 
+  /**
+   * @brief Retrieves the initial correspondences before refinement.
+   * @return A list of initial correspondences (index pairs).
+   */
   inline std::vector<std::pair<int, int>> getInitialCorrespondences() {
     return robin_matching_->getCrossCheckedCorrespondences();
   }
 
+  /**
+   * @brief Retrieves the final correspondences after refinement.
+   * @return A list of final correspondences (index pairs).
+   */
   inline std::vector<std::pair<int, int>> getFinalCorrespondences() {
     return robin_matching_->getFinalCorrespondences();
   }
 
+  /**
+   * @brief Gets the number of rotation inliers after solving.
+   * @return Number of final rotation inliers from 
+   * @graduated non-convexity (GNC) solver
+   */
   inline size_t getNumRotationInliers(){
     return solver_->getRotationInliers().size();
   }
 
+  /**
+   * @brief Gets the number of final inliers after solving.
+   * @return Number of final translation inliers from 
+   * @component-wise translation estimation (COTE)
+   * @note This number can be used to check whether the optimization is valid.
+   */
   inline size_t getNumFinalInliers(){
     return solver_->getTranslationInliers().size();
   }

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -117,10 +117,6 @@ struct KISSMatcherConfig {
 
 class KISSMatcher {
  public:
-  std::unique_ptr<FasterPFH> faster_pfh_;
-  std::unique_ptr<ROBINMatching> robin_matching_;
-  std::unique_ptr<RobustRegistrationSolver> solver_;
-
   explicit KISSMatcher(const float &voxel_size);
 
   explicit KISSMatcher(const KISSMatcherConfig &config);
@@ -180,6 +176,10 @@ class KISSMatcher {
 
  private:
   KISSMatcherConfig config_;
+
+  std::unique_ptr<FasterPFH> faster_pfh_;
+  std::unique_ptr<ROBINMatching> robin_matching_;
+  std::unique_ptr<RobustRegistrationSolver> solver_;
 
   std::vector<Eigen::Vector3f> src_keypoints_;
   std::vector<Eigen::Vector3f> tgt_keypoints_;

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -146,6 +146,14 @@ class KISSMatcher {
     return robin_matching_->getFinalCorrespondences();
   }
 
+  inline size_t getNumRotationInliers(){
+    return solver_->getRotationInliers().size();
+  }
+
+  inline size_t getNumFinalInliers(){
+    return solver_->getTranslationInliers().size();
+  }
+
   void clear() {
     src_keypoints_.clear();
     tgt_keypoints_.clear();

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -169,16 +169,32 @@ class KISSMatcher {
                                 const std::vector<Eigen::Vector3f> &dst);
 
   /**
+   * @brief Retrieves input point clouds of FasterPFH.
+   * @note Once, `config_.use_voxel_sampling_` is true, it outputs voxelized clouds
+   * @return A pair of nput point clouds.
+   */
+  inline KeypointPair getProcessedInputClouds() {
+    return {src_processed_, tgt_processed_};
+  }
+
+  /**
    * @brief Retrieves keypoints detected from FasterPFH.
+   * @note The number of these keypoints is slightly smaller than 
+   * or equal to the number of processed clouds.
    * @return A pair of keypoints from FasterPFH.
    */
-  KeypointPair getKeypointsFromFasterPFH();
+  inline KeypointPair getKeypointsFromFasterPFH() {
+    return {src_keypoints_, tgt_keypoints_};
+  }
 
   /**
    * @brief Retrieves keypoints from the initial matching stage.
+   * @note This function should be called after `match` function
    * @return A pair of initially matched keypoints.
    */
-  KeypointPair getKeypointsFromInitialMatching();
+  inline KeypointPair getKeypointsFromInitialMatching() {
+    return {src_matched_, tgt_matched_};
+  }
 
   /**
    * @brief Retrieves the initial correspondences before refinement.
@@ -216,6 +232,8 @@ class KISSMatcher {
   }
 
   void clear() {
+    src_processed_.clear();
+    tgt_processed_.clear();
     src_keypoints_.clear();
     tgt_keypoints_.clear();
     src_keypoints_.clear();
@@ -249,6 +267,9 @@ class KISSMatcher {
   std::unique_ptr<FasterPFH> faster_pfh_;
   std::unique_ptr<ROBINMatching> robin_matching_;
   std::unique_ptr<RobustRegistrationSolver> solver_;
+
+  std::vector<Eigen::Vector3f> src_processed_;
+  std::vector<Eigen::Vector3f> tgt_processed_;
 
   std::vector<Eigen::Vector3f> src_keypoints_;
   std::vector<Eigen::Vector3f> tgt_keypoints_;

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -138,11 +138,11 @@ class KISSMatcher {
 
   KeypointPair getKeypointsFromInitialMatching();
 
-  std::vector<std::pair<int, int>> getInitialCorrespondences() {
+  inline std::vector<std::pair<int, int>> getInitialCorrespondences() {
     return robin_matching_->getCrossCheckedCorrespondences();
   }
 
-  std::vector<std::pair<int, int>> getFinalCorrespondences() {
+  inline std::vector<std::pair<int, int>> getFinalCorrespondences() {
     return robin_matching_->getFinalCorrespondences();
   }
 

--- a/python/examples/run_kiss_matcher.py
+++ b/python/examples/run_kiss_matcher.py
@@ -102,6 +102,18 @@ if __name__ == "__main__":
     result = matcher.estimate(src, tgt)
     matcher.print()
 
+    num_rot_inliers = matcher.get_num_rotation_inliers()
+    num_final_inliers = matcher.get_num_final_inliers()
+    # NOTE(hlim): By checking the final inliers, we can determine whether 
+    # the registration was successful or not. The larger the threshold,
+    # the more conservatively the decision is made.
+    # See https://github.com/MIT-SPARK/KISS-Matcher/issues/24
+    thres_num_inliers = 5
+    if (num_final_inliers < thres_num_inliers):
+        print("\033[1;33m=> Registration might have failed :(\033[0m\n")
+    else:
+        print("\033[1;32m=> Registration likely succeeded XD\033[0m\n")
+
     # ------------------------------------------------------------
     # Visualization
     # ------------------------------------------------------------

--- a/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
+++ b/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
@@ -47,38 +47,6 @@ PYBIND11_MODULE(kiss_matcher, m) {
   m.doc()               = "Pybind11 bindings for KISSMatcher library";
   m.attr("__version__") = "0.3.1";
 
-  // auto vector3fvector = pybind_eigen_vector_of_vector<Eigen::Vector3f>(
-  //     m,
-  //     "_Vector3fVector",
-  //     "std::vector<Eigen::Vector3f>",
-  //     py::py_array_to_vectors_float<Eigen::Vector3f>);
-
-  // auto vector3dvector = pybind_eigen_vector_of_vector<Eigen::Vector3d>(
-  //     m,
-  //     "_Vector3dVector",
-  //     "std::vector<Eigen::Vector3d>",
-  //     py::py_array_to_vectors_double<Eigen::Vector3d>);
-
-  // Bind KISSMatcherConfig
-  // py::class_<KISSMatcherConfig>(m, "KISSMatcherConfig")
-  //     .def(py::init<float, bool, float, int, float, float, float, float>(),
-  //          "voxel_size"_a              = 0.3,
-  //          "use_quatro"_a              = false,
-  //          "thr_linearity"_a           = 1.0,
-  //          "num_max_corr"_a            = 5000,
-  //          "normal_r_gain"_a           = 3.0,
-  //          "fpfh_r_gain"_a             = 5.0,
-  //          "robin_noise_bound_gain"_a  = 1.0,
-  //          "solver_noise_bound_gain"_a = 0.75)
-  //     .def_readwrite("voxel_size", &KISSMatcherConfig::voxel_size_)
-  //     .def_readwrite("normal_radius", &KISSMatcherConfig::normal_radius_)
-  //     .def_readwrite("fpfh_radius", &KISSMatcherConfig::fpfh_radius_)
-  //     .def_readwrite("thr_linearity", &KISSMatcherConfig::thr_linearity_)
-  //     .def_readwrite("robin_noise_bound_gain", &KISSMatcherConfig::robin_noise_bound_gain_)
-  //     .def_readwrite("solver_noise_bound_gain", &KISSMatcherConfig::solver_noise_bound_gain_)
-  //     .def_readwrite("num_max_corr", &KISSMatcherConfig::num_max_corr_)
-  //     .def_readwrite("use_quatro", &KISSMatcherConfig::use_quatro_);
-
   py::class_<KISSMatcherConfig>(m, "KISSMatcherConfig")
       .def(py::init<float, bool, bool, float, int, float, float, float, float, bool>(),
            "voxel_size"_a                  = 0.3,
@@ -118,14 +86,14 @@ PYBIND11_MODULE(kiss_matcher, m) {
       .def("match",
            py::overload_cast<const std::vector<Eigen::Vector3f> &,
                              const std::vector<Eigen::Vector3f> &>(&KISSMatcher::match),
-           "src_voxelized"_a,
-           "tgt_voxelized"_a,
+           "src"_a,
+           "tgt"_a,
            "Match keypoints from source and target")
       .def("match",
            py::overload_cast<const Eigen::Matrix<double, 3, Eigen::Dynamic> &,
                              const Eigen::Matrix<double, 3, Eigen::Dynamic> &>(&KISSMatcher::match),
-           "src_voxelized"_a,
-           "tgt_voxelized"_a,
+           "src"_a,
+           "tgt"_a,
            "Match keypoints from Eigen matrices")
       .def("estimate", &KISSMatcher::estimate, "src"_a, "dst"_a, "Estimate transformation")
       .def("get_keypoints_from_faster_pfh",
@@ -140,7 +108,14 @@ PYBIND11_MODULE(kiss_matcher, m) {
       .def("get_final_correspondences",
            &KISSMatcher::getFinalCorrespondences,
            "Get final correspondences")
+      .def("get_num_rotation_inliers",
+           &KISSMatcher::getNumRotationInliers,
+           "Get # of rotation inliers")
+      .def("get_num_final_inliers",
+           &KISSMatcher::getNumFinalInliers,
+           "Get # of translation inliers")
       .def("clear", &KISSMatcher::clear, "Clear internal states")
+      .def("get_processing_time", &KISSMatcher::getProcessingTime, "Get processing (i.e., voxelization) time")
       .def("get_extraction_time", &KISSMatcher::getExtractionTime, "Get feature extraction time")
       .def("get_rejection_time", &KISSMatcher::getRejectionTime, "Get outlier rejection time")
       .def("get_matching_time", &KISSMatcher::getMatchingTime, "Get matching time")


### PR DESCRIPTION
Reflecting #24, I added explanation about how to check the reliability of the matching.

In addition, as KISS-Matcher now includes voxelization, `src_voxelized_` and `tgt_voxelized_` were wrong names. 

Thus, I change them as `src` and `tgt`.

Finally, added annotations and cleanup codes. 