### PR TITLE
Feature/prune and matching

### DIFF
--- a/cpp/examples/src/run_kiss_matcher.cc
+++ b/cpp/examples/src/run_kiss_matcher.cc
@@ -90,10 +90,10 @@ int main(int argc, char** argv) {
 
   matcher.print();
 
-  size_t num_rot_inliers = matcher.getNumRotationInliers();
+  size_t num_rot_inliers   = matcher.getNumRotationInliers();
   size_t num_final_inliers = matcher.getNumFinalInliers();
 
-  // NOTE(hlim): By checking the final inliers, we can determine whether 
+  // NOTE(hlim): By checking the final inliers, we can determine whether
   // the registration was successful or not. The larger the threshold,
   // the more conservatively the decision is made.
   // See https://github.com/MIT-SPARK/KISS-Matcher/issues/24

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
@@ -61,12 +61,12 @@ kiss_matcher::KeypointPair KISSMatcher::match(const std::vector<Eigen::Vector3f>
 
   faster_pfh_->setInputCloud(src_processed_);
   // Note(hlim) Some erroneous points are filtered out
-  // Thus, # of `src_keypoints_` <= `src_voxelized`
+  // Thus, # of `src_keypoints_` <= `src_processed_`
   faster_pfh_->ComputeFeature(src_keypoints_, src_descriptors_);
 
   faster_pfh_->setInputCloud(tgt_processed_);
   // Note(hlim) Some erroneous points are filtered out
-  // Thus, # of `tgt_keypoints_` <= `tgt_voxelized`
+  // Thus, # of `tgt_keypoints_` <= `tgt_processed_`
   faster_pfh_->ComputeFeature(tgt_keypoints_, tgt_descriptors_);
 
   auto t_mid = std::chrono::high_resolution_clock::now();

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
@@ -116,7 +116,6 @@ kiss_matcher::KeypointPair KISSMatcher::match(const Eigen::Matrix<double, 3, Eig
 
 kiss_matcher::RegistrationSolution KISSMatcher::estimate(const std::vector<Eigen::Vector3f> &src,
                                                          const std::vector<Eigen::Vector3f> &tgt) {
-  resetSolver();
   const auto &[src_matched, tgt_matched] = match(src, tgt);
   size_t M                               = src_matched.size();
 
@@ -141,6 +140,7 @@ RegistrationSolution KISSMatcher::solve(
     return solver_->getSolution();
   }
 
+  resetSolver();
   std::chrono::steady_clock::time_point t_start = std::chrono::steady_clock::now();
   solver_->solve(src_matched, tgt_matched);
   std::chrono::steady_clock::time_point t_end = std::chrono::steady_clock::now();

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
@@ -99,9 +99,8 @@ kiss_matcher::KeypointPair KISSMatcher::match(const std::vector<Eigen::Vector3f>
   return {src_matched_, tgt_matched_};
 }
 
-kiss_matcher::KeypointPair KISSMatcher::match(
-    const Eigen::Matrix<double, 3, Eigen::Dynamic> &src,
-    const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt) {
+kiss_matcher::KeypointPair KISSMatcher::match(const Eigen::Matrix<double, 3, Eigen::Dynamic> &src,
+                                              const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt) {
   std::vector<Eigen::Vector3f> src_vec(src.cols());
   std::vector<Eigen::Vector3f> tgt_vec(tgt.cols());
 
@@ -116,9 +115,9 @@ kiss_matcher::KeypointPair KISSMatcher::match(
 }
 
 kiss_matcher::RegistrationSolution KISSMatcher::estimate(const std::vector<Eigen::Vector3f> &src,
-                                                         const std::vector<Eigen::Vector3f> &dst) {
+                                                         const std::vector<Eigen::Vector3f> &tgt) {
   resetSolver();
-  const auto &[src_matched, tgt_matched] = match(src, dst);
+  const auto &[src_matched, tgt_matched] = match(src, tgt);
   size_t M                               = src_matched.size();
 
   Eigen::Matrix<double, 3, Eigen::Dynamic> src_matched_eigen;
@@ -130,19 +129,44 @@ kiss_matcher::RegistrationSolution KISSMatcher::estimate(const std::vector<Eigen
     src_matched_eigen.col(m) << src_matched[m].cast<double>();
     tgt_matched_eigen.col(m) << tgt_matched[m].cast<double>();
   }
+  return solve(src_matched_eigen, tgt_matched_eigen);
+}
 
+RegistrationSolution KISSMatcher::solve(
+    const Eigen::Matrix<double, 3, Eigen::Dynamic> &src_matched,
+    const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt_matched) {
   // In case of too-few matching pairs,
   // Just return invalid solution with the identity matrix
-  if (M < 2) {
+  if (src_matched.cols() < 2) {
     return solver_->getSolution();
   }
 
   std::chrono::steady_clock::time_point t_start = std::chrono::steady_clock::now();
-  solver_->solve(src_matched_eigen, tgt_matched_eigen);
+  solver_->solve(src_matched, tgt_matched);
   std::chrono::steady_clock::time_point t_end = std::chrono::steady_clock::now();
   solver_time_ = std::chrono::duration_cast<std::chrono::duration<double>>(t_end - t_start).count();
 
   return solver_->getSolution();
+}
+
+RegistrationSolution KISSMatcher::pruneAndSolve(const std::vector<Eigen::Vector3f> &src_matched,
+                                                const std::vector<Eigen::Vector3f> &tgt_matched) {
+  std::vector<std::pair<int, int>> corres, corres_out;
+  for (size_t i = 0; i < src_matched.size(); ++i) {
+    corres.emplace_back(i, i);
+  }
+  const auto &pruned_indices =
+      robin_matching_->applyOutlierPruning(src_matched, tgt_matched, "max_core");
+  size_t num_pruned_corr = pruned_indices.size();
+
+  Eigen::Matrix<double, 3, Eigen::Dynamic> src_eigen(3, num_pruned_corr);
+  Eigen::Matrix<double, 3, Eigen::Dynamic> tgt_eigen(3, num_pruned_corr);
+
+  for (size_t i = 0; i < num_pruned_corr; ++i) {
+    src_eigen.col(i) = src_matched[num_pruned_corr].cast<double>();
+    tgt_eigen.col(i) = tgt_matched[num_pruned_corr].cast<double>();
+  }
+  return solve(src_eigen, tgt_eigen);
 }
 
 double KISSMatcher::getProcessingTime() { return processing_time_; }

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -168,9 +168,24 @@ class KISSMatcher {
   RegistrationSolution estimate(const std::vector<Eigen::Vector3f> &src,
                                 const std::vector<Eigen::Vector3f> &tgt);
 
+  /**
+   * @brief Solves for the optimal transformation using matched keypoints.
+   * This function assumes that the correspondences have already been established.
+   * @param src_matched Source keypoints matrix.
+   * @param tgt_matched Target keypoints matrix.
+   * @return The estimated registration solution.
+   */
   RegistrationSolution solve(const Eigen::Matrix<double, 3, Eigen::Dynamic> &src_matched,
                              const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt_matched);
 
+  /**
+   * @brief Prunes outliers and then solves for registration.
+   * This function applies outlier filtering before estimating the transformation,
+   * and assumes that the correspondences have already been established.
+   * @param src_matched Source point cloud keypoints.
+   * @param tgt_matched Target point cloud keypoints.
+   * @return The estimated registration solution after pruning.
+   */
   RegistrationSolution pruneAndSolve(const std::vector<Eigen::Vector3f> &src_matched,
                                      const std::vector<Eigen::Vector3f> &tgt_matched);
 

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -168,33 +168,33 @@ class KISSMatcher {
   RegistrationSolution estimate(const std::vector<Eigen::Vector3f> &src,
                                 const std::vector<Eigen::Vector3f> &tgt);
 
+  RegistrationSolution solve(const Eigen::Matrix<double, 3, Eigen::Dynamic> &src_matched,
+                             const Eigen::Matrix<double, 3, Eigen::Dynamic> &tgt_matched);
+
+  RegistrationSolution pruneAndSolve(const std::vector<Eigen::Vector3f> &src_matched,
+                                     const std::vector<Eigen::Vector3f> &tgt_matched);
+
   /**
    * @brief Retrieves input point clouds of FasterPFH.
    * @note Once, `config_.use_voxel_sampling_` is true, it outputs voxelized clouds
    * @return A pair of nput point clouds.
    */
-  inline KeypointPair getProcessedInputClouds() {
-    return {src_processed_, tgt_processed_};
-  }
+  inline KeypointPair getProcessedInputClouds() { return {src_processed_, tgt_processed_}; }
 
   /**
    * @brief Retrieves keypoints detected from FasterPFH.
-   * @note The number of these keypoints is slightly smaller than 
+   * @note The number of these keypoints is slightly smaller than
    * or equal to the number of processed clouds.
    * @return A pair of keypoints from FasterPFH.
    */
-  inline KeypointPair getKeypointsFromFasterPFH() {
-    return {src_keypoints_, tgt_keypoints_};
-  }
+  inline KeypointPair getKeypointsFromFasterPFH() { return {src_keypoints_, tgt_keypoints_}; }
 
   /**
    * @brief Retrieves keypoints from the initial matching stage.
    * @note This function should be called after `match` function
    * @return A pair of initially matched keypoints.
    */
-  inline KeypointPair getKeypointsFromInitialMatching() {
-    return {src_matched_, tgt_matched_};
-  }
+  inline KeypointPair getKeypointsFromInitialMatching() { return {src_matched_, tgt_matched_}; }
 
   /**
    * @brief Retrieves the initial correspondences before refinement.
@@ -214,22 +214,18 @@ class KISSMatcher {
 
   /**
    * @brief Gets the number of rotation inliers after solving.
-   * @return Number of final rotation inliers from 
+   * @return Number of final rotation inliers from
    * @graduated non-convexity (GNC) solver
    */
-  inline size_t getNumRotationInliers(){
-    return solver_->getRotationInliers().size();
-  }
+  inline size_t getNumRotationInliers() { return solver_->getRotationInliers().size(); }
 
   /**
    * @brief Gets the number of final inliers after solving.
-   * @return Number of final translation inliers from 
+   * @return Number of final translation inliers from
    * @component-wise translation estimation (COTE)
    * @note This number can be used to check whether the optimization is valid.
    */
-  inline size_t getNumFinalInliers(){
-    return solver_->getTranslationInliers().size();
-  }
+  inline size_t getNumFinalInliers() { return solver_->getTranslationInliers().size(); }
 
   void clear() {
     src_processed_.clear();

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -162,11 +162,11 @@ class KISSMatcher {
   /**
    * @brief Estimates the transformation between source and target point clouds.
    * @param src Source point cloud.
-   * @param dst Target point cloud.
+   * @param tgt Target point cloud.
    * @return The estimated registration solution.
    */
   RegistrationSolution estimate(const std::vector<Eigen::Vector3f> &src,
-                                const std::vector<Eigen::Vector3f> &dst);
+                                const std::vector<Eigen::Vector3f> &tgt);
 
   /**
    * @brief Retrieves input point clouds of FasterPFH.

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
@@ -298,6 +298,8 @@ void ROBINMatching::runTupleTestWithROBIN(const std::vector<std::pair<int, int>>
     auto* g = robin::Make3dRegInvGraph(src_robin, tgt_robin, noise_bound_);
 
     const auto& filtered_indices = [&]() {
+      // NOTE(hlim): Just use max core mode.
+      // `max_clique` not only took more time but also showed slightly worse performance.
       if (robin_mode == "max_core") {
         return robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
       } else if (robin_mode == "max_clique") {

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
@@ -143,7 +143,7 @@ void ROBINMatching::match(const std::string& robin_mode, float tuple_scale, bool
   if (robin_mode == "None") {
     runTupleTest(corres_cross_checked_, corres_, tuple_scale);
   } else if (robin_mode == "max_core" || robin_mode == "max_clique") {
-    runTupleTestWithROBIN(corres_cross_checked_, corres_, robin_mode);
+    applyOutlierPruning(corres_cross_checked_, corres_, robin_mode);
   } else {
     std::invalid_argument("Wrong ROBIN mode has come.");
   }
@@ -278,9 +278,9 @@ void ROBINMatching::runTupleTest(const std::vector<std::pair<int, int>>& corres,
   }
 }
 
-void ROBINMatching::runTupleTestWithROBIN(const std::vector<std::pair<int, int>>& corres,
-                                          std::vector<std::pair<int, int>>& corres_out,
-                                          const std::string& robin_mode) {
+void ROBINMatching::applyOutlierPruning(const std::vector<std::pair<int, int>>& corres,
+                                      std::vector<std::pair<int, int>>& corres_out,
+                                      const std::string& robin_mode) {
   if (!corres.empty()) {
     size_t ncorr = corres.size();
     std::vector<bool> is_already_included(ncorr, false);

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
@@ -325,6 +325,44 @@ void ROBINMatching::applyOutlierPruning(const std::vector<std::pair<int, int>>& 
   }
 }
 
+std::vector<size_t> ROBINMatching::applyOutlierPruning(const std::vector<Eigen::Vector3f> &src_matched,
+                                        const std::vector<Eigen::Vector3f> &tgt_matched,
+                                        const std::string& robin_mode) {
+  if (src_matched.size() != tgt_matched.size()) {
+    std::runtime_error("The size of `src_matched` and `tgt_matched` should be same.");
+  }
+if (src_matched.size() < 2 || tgt_matched.size() < 2) {
+    std::runtime_error("Too few matched points are given.");
+  }
+
+  Eigen::Matrix<double, 3, Eigen::Dynamic> src_robin(3, src_matched.size());
+  Eigen::Matrix<double, 3, Eigen::Dynamic> tgt_robin(3, tgt_matched.size());
+
+  num_init_corr_ = src_matched.size();
+#pragma omp parallel for
+  for (size_t i = 0; i < num_init_corr_; ++i) {
+    src_robin.col(i) = src_matched[i].cast<double>();
+    tgt_robin.col(i) = tgt_matched[i].cast<double>();
+  }
+
+  auto* g = robin::Make3dRegInvGraph(src_robin, tgt_robin, noise_bound_);
+
+  const auto& filtered_indices = [&]() {
+    // NOTE(hlim): Just use max core mode.
+    // `max_clique` not only took more time but also showed slightly worse performance.
+    if (robin_mode == "max_core") {
+      return robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CORE);
+    } else if (robin_mode == "max_clique") {
+      return robin::FindInlierStructure(g, robin::InlierGraphStructure::MAX_CLIQUE);
+    } else {
+      throw std::runtime_error("Something's wrong!");
+    }
+  }();
+
+  num_pruned_corr_ = filtered_indices.size();
+  return filtered_indices;
+}
+
 template <typename T>
 void ROBINMatching::buildKDTree(const std::vector<T>& data, ROBINMatching::KDTree* tree) {
   int rows, dim;

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
@@ -279,8 +279,8 @@ void ROBINMatching::runTupleTest(const std::vector<std::pair<int, int>>& corres,
 }
 
 void ROBINMatching::applyOutlierPruning(const std::vector<std::pair<int, int>>& corres,
-                                      std::vector<std::pair<int, int>>& corres_out,
-                                      const std::string& robin_mode) {
+                                        std::vector<std::pair<int, int>>& corres_out,
+                                        const std::string& robin_mode) {
   if (!corres.empty()) {
     size_t ncorr = corres.size();
     std::vector<bool> is_already_included(ncorr, false);
@@ -325,13 +325,14 @@ void ROBINMatching::applyOutlierPruning(const std::vector<std::pair<int, int>>& 
   }
 }
 
-std::vector<size_t> ROBINMatching::applyOutlierPruning(const std::vector<Eigen::Vector3f> &src_matched,
-                                        const std::vector<Eigen::Vector3f> &tgt_matched,
-                                        const std::string& robin_mode) {
+std::vector<size_t> ROBINMatching::applyOutlierPruning(
+    const std::vector<Eigen::Vector3f>& src_matched,
+    const std::vector<Eigen::Vector3f>& tgt_matched,
+    const std::string& robin_mode) {
   if (src_matched.size() != tgt_matched.size()) {
     std::runtime_error("The size of `src_matched` and `tgt_matched` should be same.");
   }
-if (src_matched.size() < 2 || tgt_matched.size() < 2) {
+  if (src_matched.size() < 2 || tgt_matched.size() < 2) {
     std::runtime_error("Too few matched points are given.");
   }
 

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
@@ -49,7 +49,12 @@ class ROBINMatching {
       float tuple_scale   = 0.95,
       bool use_ratio_test = false);
 
-  std::vector<std::pair<int, int>> getCrossCheckedCorrespondences() {
+  // For a deeper understanding, please refer to Section III.D
+  // ttps://arxiv.org/pdf/2409.15615
+  std::vector<size_t> applyOutlierPruning(const std::vector<Eigen::Vector3f> &src_matched,
+                           const std::vector<Eigen::Vector3f> &tgt_matched,
+                           const std::string& robin_mode="max_core");
+
   inline std::vector<std::pair<int, int>> getCrossCheckedCorrespondences() {
     std::vector<std::pair<int, int>> corres_out;
     corres_out.reserve(corres_cross_checked_.size());

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
@@ -50,6 +50,7 @@ class ROBINMatching {
       bool use_ratio_test = false);
 
   std::vector<std::pair<int, int>> getCrossCheckedCorrespondences() {
+  inline std::vector<std::pair<int, int>> getCrossCheckedCorrespondences() {
     std::vector<std::pair<int, int>> corres_out;
     corres_out.reserve(corres_cross_checked_.size());
     for (const auto& corres_tuple : corres_cross_checked_) {
@@ -62,11 +63,12 @@ class ROBINMatching {
     return corres_out;
   }
 
-  std::vector<std::pair<int, int>> getCrosscheckedCorrespondences() {
+  inline std::vector<std::pair<int, int>> getCrosscheckedCorrespondences() {
     return corres_cross_checked_;
   }
 
-  std::vector<std::pair<int, int>> getFinalCorrespondences() { return corres_; }
+  
+  inline std::vector<std::pair<int, int>> getFinalCorrespondences() { return corres_; }
 
   double getRejectionTime() { return rejection_time_; }
 
@@ -115,9 +117,10 @@ class ROBINMatching {
   // For a deeper understanding, please refer to Section III.D
   // ttps://arxiv.org/pdf/2409.15615
   void applyOutlierPruning(const std::vector<std::pair<int, int>>& corres,
-                             std::vector<std::pair<int, int>>& corres_out,
-                             const std::string& robin_mode);
+                           std::vector<std::pair<int, int>>& corres_out,
+                           const std::string& robin_mode="max_core");
 
+  
   std::vector<std::pair<int, int>> corres_cross_checked_;
   std::vector<std::pair<int, int>> corres_;
   std::vector<std::vector<Eigen::Vector3f>> pointcloud_;

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
@@ -112,7 +112,9 @@ class ROBINMatching {
                     std::vector<std::pair<int, int>>& corres_out,
                     const float tuple_scale);
 
-  void runTupleTestWithROBIN(const std::vector<std::pair<int, int>>& corres,
+  // For a deeper understanding, please refer to Section III.D
+  // ttps://arxiv.org/pdf/2409.15615
+  void applyOutlierPruning(const std::vector<std::pair<int, int>>& corres,
                              std::vector<std::pair<int, int>>& corres_out,
                              const std::string& robin_mode);
 

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
@@ -51,9 +51,9 @@ class ROBINMatching {
 
   // For a deeper understanding, please refer to Section III.D
   // ttps://arxiv.org/pdf/2409.15615
-  std::vector<size_t> applyOutlierPruning(const std::vector<Eigen::Vector3f> &src_matched,
-                           const std::vector<Eigen::Vector3f> &tgt_matched,
-                           const std::string& robin_mode="max_core");
+  std::vector<size_t> applyOutlierPruning(const std::vector<Eigen::Vector3f>& src_matched,
+                                          const std::vector<Eigen::Vector3f>& tgt_matched,
+                                          const std::string& robin_mode = "max_core");
 
   inline std::vector<std::pair<int, int>> getCrossCheckedCorrespondences() {
     std::vector<std::pair<int, int>> corres_out;
@@ -72,7 +72,6 @@ class ROBINMatching {
     return corres_cross_checked_;
   }
 
-  
   inline std::vector<std::pair<int, int>> getFinalCorrespondences() { return corres_; }
 
   double getRejectionTime() { return rejection_time_; }
@@ -123,9 +122,8 @@ class ROBINMatching {
   // ttps://arxiv.org/pdf/2409.15615
   void applyOutlierPruning(const std::vector<std::pair<int, int>>& corres,
                            std::vector<std::pair<int, int>>& corres_out,
-                           const std::string& robin_mode="max_core");
+                           const std::string& robin_mode = "max_core");
 
-  
   std::vector<std::pair<int, int>> corres_cross_checked_;
   std::vector<std::pair<int, int>> corres_;
   std::vector<std::vector<Eigen::Vector3f>> pointcloud_;

--- a/python/examples/run_kiss_matcher.py
+++ b/python/examples/run_kiss_matcher.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
 
     num_rot_inliers = matcher.get_num_rotation_inliers()
     num_final_inliers = matcher.get_num_final_inliers()
-    # NOTE(hlim): By checking the final inliers, we can determine whether 
+    # NOTE(hlim): By checking the final inliers, we can determine whether
     # the registration was successful or not. The larger the threshold,
     # the more conservatively the decision is made.
     # See https://github.com/MIT-SPARK/KISS-Matcher/issues/24

--- a/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
+++ b/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
@@ -95,7 +95,7 @@ PYBIND11_MODULE(kiss_matcher, m) {
            "src"_a,
            "tgt"_a,
            "Match keypoints from Eigen matrices")
-      .def("estimate", &KISSMatcher::estimate, "src"_a, "dst"_a, "Estimate transformation")
+      .def("estimate", &KISSMatcher::estimate, "src"_a, "tgt"_a, "Estimate transformation")
       .def("get_keypoints_from_faster_pfh",
            &KISSMatcher::getKeypointsFromFasterPFH,
            "Get keypoints from FasterPFH")

--- a/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
+++ b/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
@@ -111,11 +111,12 @@ PYBIND11_MODULE(kiss_matcher, m) {
       .def("get_num_rotation_inliers",
            &KISSMatcher::getNumRotationInliers,
            "Get # of rotation inliers")
-      .def("get_num_final_inliers",
-           &KISSMatcher::getNumFinalInliers,
-           "Get # of translation inliers")
+      .def(
+          "get_num_final_inliers", &KISSMatcher::getNumFinalInliers, "Get # of translation inliers")
       .def("clear", &KISSMatcher::clear, "Clear internal states")
-      .def("get_processing_time", &KISSMatcher::getProcessingTime, "Get processing (i.e., voxelization) time")
+      .def("get_processing_time",
+           &KISSMatcher::getProcessingTime,
+           "Get processing (i.e., voxelization) time")
       .def("get_extraction_time", &KISSMatcher::getExtractionTime, "Get feature extraction time")
       .def("get_rejection_time", &KISSMatcher::getRejectionTime, "Get outlier rejection time")
       .def("get_matching_time", &KISSMatcher::getMatchingTime, "Get matching time")

--- a/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
+++ b/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
@@ -96,6 +96,19 @@ PYBIND11_MODULE(kiss_matcher, m) {
            "tgt"_a,
            "Match keypoints from Eigen matrices")
       .def("estimate", &KISSMatcher::estimate, "src"_a, "tgt"_a, "Estimate transformation")
+      .def("solve",
+           &KISSMatcher::solve,
+           "src_matched"_a,
+           "tgt_matched"_a,
+           "Estimate relative pose given already matched point clouds")
+      .def("prune_and_solve",
+           &KISSMatcher::pruneAndSolve,
+           "src_matched"_a,
+           "tgt_matched"_a,
+           "Prune correspondences and estimate relative pose given already matched point clouds")
+      .def("get_processed_input_clouds",
+           &KISSMatcher::getProcessedInputClouds,
+           "Get processed (i.e., voxelization) point clouds")
       .def("get_keypoints_from_faster_pfh",
            &KISSMatcher::getKeypointsFromFasterPFH,
            "Get keypoints from FasterPFH")


### PR DESCRIPTION
This pull request includes several changes to the `KISSMatcher` and `ROBINMatching` classes, focusing on improving the matching and registration process, adding new methods, and refining existing functionality. The most important changes are summarized below.

### Enhancements to `KISSMatcher`:

* Updated comments to reflect the correct variable names (`src_processed_` and `tgt_processed_`) in the `KISSMatcher::match` method.
* Added new methods `solve` and `pruneAndSolve` to the `KISSMatcher` class to handle solving for transformations and pruning outliers before solving. [[1]](diffhunk://#diff-fb349e2de025d40522ccabe9a4df64f4bb3fb1bbaf28ee406b73437495c2dd35R131-R171) [[2]](diffhunk://#diff-22fa8fc8ba2089b7573d5a609b8a9418c086b2b820a620cbc65ca7701e7df376L165-R212)
* Modified the `estimate` method to use the new `solve` method and removed the call to `resetSolver()`.

### Enhancements to `ROBINMatching`:

* Renamed the method `runTupleTestWithROBIN` to `applyOutlierPruning` and updated its logic to improve outlier pruning. [[1]](diffhunk://#diff-38e26eb328e1c00d823956ad9fb7f93c179f46124dbb3304cd0dd00a50f780d9L281-R281) [[2]](diffhunk://#diff-38e26eb328e1c00d823956ad9fb7f93c179f46124dbb3304cd0dd00a50f780d9R328-R366)
* Added a new method `applyOutlierPruning` that prunes outliers and returns the filtered indices. [[1]](diffhunk://#diff-38e26eb328e1c00d823956ad9fb7f93c179f46124dbb3304cd0dd00a50f780d9R328-R366) [[2]](diffhunk://#diff-d9f976e2dd635d75561e196076c6695ceb16abc43b0e8db9e61d88ad8c6ed3d0L52-R58)

### Python Bindings:

* Added bindings for the new `solve` and `pruneAndSolve` methods in the `KISSMatcher` class to the Python module.
* Updated the binding for the `estimate` method to use the correct parameter name `tgt`.