### PR TITLE
ros2 build and warnings fixes.

### DIFF
--- a/cpp/examples/CMakeLists.txt
+++ b/cpp/examples/CMakeLists.txt
@@ -1,11 +1,16 @@
 cmake_minimum_required(VERSION 3.10)
 project(kiss_matcher_example)
 
+# Set a default build type if none is specified
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+    # Provide options for cmake-gui or ccmake
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 set(CMAKE_CXX_STANDARD 17)
-
-if (NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release")
-endif ()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(FetchContent)
 

--- a/cpp/kiss_matcher/CMakeLists.txt
+++ b/cpp/kiss_matcher/CMakeLists.txt
@@ -6,17 +6,23 @@ option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
 option(USE_SYSTEM_TBB "Use system pre-installed oneAPI/tbb" ON)
 option(USE_SYSTEM_ROBIN "Use system pre-installed ROBIN from SPARK @ MIT" ON)
 
+# Set a default build type if none is specified
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+    # Provide options for cmake-gui or ccmake
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 include(GNUInstallDirs)
 include(3rdparty/find_dependencies.cmake)
 include(cmake/CompilerOptions.cmake)
 
 # NOTE(hlim): Without this line, pybinded KISS-Matcher does not work
 find_library(LZ4_LIBRARY lz4 REQUIRED)
-
-set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(FindOpenMP) #The best way to set proper compiler settings for using OpenMP in all platforms
 if (OPENMP_FOUND) #The best way to set proper compiler settings for using OpenMP in all platforms

--- a/cpp/kiss_matcher/CMakeLists.txt
+++ b/cpp/kiss_matcher/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(${TARGET_NAME} STATIC
     core/kiss_matcher/KISSMatcher.cpp
     core/kiss_matcher/GncSolver.cpp
 )
+add_library(kiss_matcher::kiss_matcher_core ALIAS kiss_matcher_core)
 
 target_link_libraries(${TARGET_NAME}
     PUBLIC Eigen3::Eigen robin::robin ${OpenMP_LIBS} ${EIGEN3_LIBS} TBB::tbb ${LZ4_LIBRARY}

--- a/cpp/kiss_matcher/CMakeLists.txt
+++ b/cpp/kiss_matcher/CMakeLists.txt
@@ -5,6 +5,7 @@ option(USE_CCACHE "Build using Ccache if found on the path" ON)
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
 option(USE_SYSTEM_TBB "Use system pre-installed oneAPI/tbb" ON)
 option(USE_SYSTEM_ROBIN "Use system pre-installed ROBIN from SPARK @ MIT" ON)
+option(USE_ADDRESS_SANITIZER "Use address sanitizer" OFF)
 
 # Set a default build type if none is specified
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -16,6 +17,11 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+if (USE_ADDRESS_SANITIZER)
+    add_compile_options(-fsanitize=address -fsanitize-recover=address)
+    add_link_options(-fsanitize=address -fsanitize-recover=address)
+endif()
 
 include(GNUInstallDirs)
 include(3rdparty/find_dependencies.cmake)

--- a/cpp/kiss_matcher/core/kiss_matcher/FasterPFH.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/FasterPFH.cpp
@@ -58,7 +58,7 @@ std::tuple<bool, Eigen::Vector3f> FasterPFH::EstimateNormalVectorWithLinearityFi
   Eigen::Matrix3f covariance = Eigen::Matrix3f::Zero();
   int count                  = 0;
 
-  for (int j = 0; j < static_cast<size_t>(corr_fpfh.neighboring_indices.size()); ++j) {
+  for (std::size_t j = 0; j < corr_fpfh.neighboring_indices.size(); ++j) {
     if (corr_fpfh.neighboring_dists[j] < thr_radius) {
       int idx                      = corr_fpfh.neighboring_indices[j];
       const Eigen::Vector3f &point = points_[idx];
@@ -77,7 +77,7 @@ std::tuple<bool, Eigen::Vector3f> FasterPFH::EstimateNormalVectorWithLinearityFi
   mean /= static_cast<float>(count);
 
   // Calculate covariance
-  for (int j = 0; j < corr_fpfh.neighboring_indices.size(); ++j) {
+  for (std::size_t j = 0; j < corr_fpfh.neighboring_indices.size(); ++j) {
     if (corr_fpfh.neighboring_dists[j] < thr_radius) {
       Eigen::Vector3f point     = points_[corr_fpfh.neighboring_indices[j]];
       Eigen::Vector3f deviation = point - mean;
@@ -150,14 +150,16 @@ void FasterPFH::ComputeFeature(std::vector<Eigen::Vector3f> &points,
         for (uint32_t i = r.begin(); i != r.end(); ++i) {
           if (criteria_ == "L2") {
             // Then, neighboring_dists are squared distances
-            std::vector<std::pair<size_t, double> > indices_dists;
+            std::vector<std::pair<uint32_t, double> > indices_dists;
             indices_dists.reserve(1000);
             // NOTE: squared distance is used, and outputs are also squared values
             size_t num_results =
                 kdtree.radius_search(cloud_nano.point(i), sqr_fpfh_radius_, indices_dists);
-            for (const auto &[idx, sqr_dist] : indices_dists) {
-              corrs_fpfh_[i].neighboring_indices.push_back(idx);
-              corrs_fpfh_[i].neighboring_dists.push_back(sqr_dist);
+            if (num_results > 0) {
+              for (const auto &[idx, sqr_dist] : indices_dists) {
+                corrs_fpfh_[i].neighboring_indices.push_back(idx);
+                corrs_fpfh_[i].neighboring_dists.push_back(sqr_dist);
+              }
             }
           }
 

--- a/cpp/kiss_matcher/core/kiss_matcher/FasterPFH.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/FasterPFH.hpp
@@ -28,7 +28,12 @@
 
 using MyKdTree = kiss_matcher::UnsafeKdTree<kiss_matcher::PointCloud>;
 
-#define NOT_ASSIGNED -1
+// was #define NOT_ASSIGNED -1 but results in a sign comparison warning
+// as it is compared against the indices which are uint32_t or size_t
+// This quiets the warning but is probably not what is intended.
+// NEEDS thought!
+#define NOT_ASSIGNED std::numeric_limits<uint32_t>::max()
+
 #define UNASSIGNED_NORMAL                                  \
   Eigen::Vector3f(std::numeric_limits<float>::quiet_NaN(), \
                   std::numeric_limits<float>::quiet_NaN(), \

--- a/cpp/kiss_matcher/core/kiss_matcher/GncSolver.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/GncSolver.cpp
@@ -450,7 +450,7 @@ RegistrationSolution RobustRegistrationSolver::solve(
   pruned_dst_tims_.resize(3, num_corr);
   for (size_t i = 0; i < num_corr; ++i) {
     const auto& root = indices_[i];
-    int leaf;
+    size_t leaf;
     if (i != num_corr - 1) {
       leaf = indices_[i + 1];
     } else {

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.cpp
@@ -104,10 +104,10 @@ kiss_matcher::KeypointPair KISSMatcher::match(const Eigen::Matrix<double, 3, Eig
   std::vector<Eigen::Vector3f> src_vec(src.cols());
   std::vector<Eigen::Vector3f> tgt_vec(tgt.cols());
 
-  for (size_t i = 0; i < src.cols(); ++i) {
+  for (ssize_t i = 0; i < src.cols(); ++i) {
     src_vec[i] = src.col(i).cast<float>();
   }
-  for (size_t i = 0; i < tgt.cols(); ++i) {
+  for (ssize_t i = 0; i < tgt.cols(); ++i) {
     tgt_vec[i] = tgt.col(i).cast<float>();
   }
 

--- a/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/KISSMatcher.hpp
@@ -288,8 +288,13 @@ class KISSMatcher {
   std::vector<Eigen::Vector3f> src_matched_;
   std::vector<Eigen::Vector3f> tgt_matched_;
 
-  std::vector<Eigen::VectorXf> src_descriptors_;
-  std::vector<Eigen::VectorXf> tgt_descriptors_;
+  // Setup aligned attribute to keep Address Sanitizer happy during resize() and clear()
+  // The eigen docs seem to say its not required, especially with c++17 but...
+  // I(ewak) guessed and gave it a try and address sanitiser builds run clean, YMMV.
+  // add_compile_options(-fsanitize=address -fsanitize-recover=address)
+  // add_link_options(-fsanitize=address -fsanitize-recover=address)
+  std::vector<Eigen::VectorXf> __attribute__((aligned(EIGEN_MAX_ALIGN_BYTES))) src_descriptors_;
+  std::vector<Eigen::VectorXf> __attribute__((aligned(EIGEN_MAX_ALIGN_BYTES))) tgt_descriptors_;
 
   std::vector<std::pair<int, int>> corr_;
 

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.cpp
@@ -63,10 +63,10 @@ void ROBINMatching::match(const std::string& robin_mode, float tuple_scale, bool
 
   // NOTE(hlim): `2` indicates that we save the two distances between the two closest descriptors.
   int num_candidates = use_ratio_test ? 2 : 1;
-  std::vector<std::vector<int>> corres_K(nPtj_, std::vector<int>(1, 0));
-  std::vector<std::vector<int>> corres_K2(nPti_, std::vector<int>(1, 0));
+  std::vector<std::vector<int>> corres_K(nPtj_, std::vector<int>(num_candidates, 0));
+  std::vector<std::vector<int>> corres_K2(nPti_, std::vector<int>(num_candidates, 0));
   std::vector<std::vector<float>> dis_j(nPtj_, std::vector<float>(num_candidates, 0.0));
-  std::vector<std::vector<float>> dis_i(nPti_, std::vector<float>(1, 0.0));
+  std::vector<std::vector<float>> dis_i(nPti_, std::vector<float>(num_candidates, 0.0));
 
   std::vector<std::pair<int, int>> corres_ij;
   std::vector<std::pair<int, int>> corres_ji;
@@ -104,9 +104,9 @@ void ROBINMatching::match(const std::string& robin_mode, float tuple_scale, bool
   // float ratio = dis_j[j][0] / dis_j[j][1]; <- 98.56%
   // float ratio = dis_j[j][0];               <- 97.84%
   matched_pairs.reserve(nPti_);
-  for (size_t j = 0; j < nPtj_; j++) {
+  for (ssize_t j = 0; j < nPtj_; j++) {
     int ji = j_to_i_multi_flann[j];
-    if (j == i_to_j_multi_flann[ji]) {
+    if (ji != -1 && j == i_to_j_multi_flann[ji]) {
       float ratio = use_ratio_test ? dis_j[j][0] / dis_j[j][1] : 0.0;
       matched_pairs.emplace_back(ji, j, ratio);
     }
@@ -172,7 +172,7 @@ void ROBINMatching::setStatuses() {
 
 void ROBINMatching::runTupleTest(const std::vector<std::pair<int, int>>& corres,
                                  std::vector<std::pair<int, int>>& corres_out,
-                                 const float tuple_scale) {
+                                 const float /*tuple_scale*/) {
   if (!corres.empty()) {
     size_t rand0, rand1, rand2;
     size_t idi0, idi1, idi2;

--- a/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/ROBINMatching.hpp
@@ -84,8 +84,8 @@ class ROBINMatching {
   size_t fi_ = 0;  // source idx
   size_t fj_ = 1;  // destination idx
 
-  size_t nPti_;
-  size_t nPtj_;
+  ssize_t nPti_;
+  ssize_t nPtj_;
 
   bool swapped_ = false;
 

--- a/cpp/kiss_matcher/core/kiss_matcher/kdtree/kdtree.hpp
+++ b/cpp/kiss_matcher/core/kiss_matcher/kdtree/kdtree.hpp
@@ -21,7 +21,7 @@ class UnsafeKdTreeGeneric {
   using ConstPtr  = std::shared_ptr<const UnsafeKdTreeGeneric>;
   using ThisClass = UnsafeKdTreeGeneric<PointCloud, Adaptor>;
   using Index =
-      Adaptor<kiss_matcher::L2_Simple_Adaptor<double, ThisClass, double>, ThisClass, 3, size_t>;
+      Adaptor<kiss_matcher::L2_Simple_Adaptor<double, ThisClass, double>, ThisClass, 3, uint32_t>;
 
   /// @brief Constructor
   /// @param points  Input points
@@ -63,7 +63,7 @@ class UnsafeKdTreeGeneric {
   /// @brief Find neighbors within the radius
   size_t radius_search(const Eigen::Vector4d &pt,
                        double r,
-                       std::vector<std::pair<size_t, double>> &indices_sq_dists) const {
+                       std::vector<std::pair<uint32_t, double>> &indices_sq_dists) const {
     kiss_matcher::SearchParams params;
     params.sorted = false;  // to boost the speed
     return index.radiusSearch(pt.data(), r, indices_sq_dists, params);
@@ -104,7 +104,7 @@ class KdTreeGeneric {
   /// @brief Find neighbors within the radius
   size_t radius_search(const Eigen::Vector4d &pt,
                        double r,
-                       std::vector<std::pair<size_t, double>> &indices_sq_dists) const {
+                       std::vector<std::pair<uint32_t, double>> &indices_sq_dists) const {
     kiss_matcher::SearchParams params;
     params.sorted = false;  // to boost the speed
     return tree.radius_search(pt.data(), r, indices_sq_dists, params);
@@ -138,7 +138,7 @@ struct Traits<UnsafeKdTreeGeneric<PointCloud, Adaptor>> {
   static size_t radius_search(const UnsafeKdTreeGeneric<PointCloud, Adaptor> &tree,
                               const Eigen::Vector4d &point,
                               double r,
-                              std::vector<std::pair<size_t, double>> &indices_sq_dists) {
+                              std::vector<std::pair<uint32_t, double>> &indices_sq_dists) {
     kiss_matcher::SearchParams params;
     params.sorted = false;  // to boost the speed
     return tree.radius_search(point, r, indices_sq_dists);
@@ -158,7 +158,7 @@ struct Traits<KdTreeGeneric<PointCloud, Adaptor>> {
   static size_t radius_search(const KdTreeGeneric<PointCloud, Adaptor> &tree,
                               const Eigen::Vector4d &point,
                               double r,
-                              std::vector<std::pair<size_t, double>> &indices_sq_dists) {
+                              std::vector<std::pair<uint32_t, double>> &indices_sq_dists) {
     kiss_matcher::SearchParams params;
     params.sorted = false;  // to boost the speed
     return tree.radius_search(point, r, indices_sq_dists);

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.8)
 project(kiss_matcher_ros)
 
+# Set a default build type if none is specified
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+    # Provide options for cmake-gui or ccmake
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -23,10 +23,12 @@ find_package(sensor_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(PCL REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 add_executable(registration_visualizer src/registration_visualizer.cpp)
 ament_target_dependencies(registration_visualizer
   rclcpp
+  tf2_ros
   sensor_msgs
   pcl_conversions
   PCL

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -25,6 +25,25 @@ find_package(PCL REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(tf2_ros REQUIRED)
 
+find_package(PCL REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
+add_executable(run_kiss_matcher src/run_kiss_matcher.cpp)
+target_include_directories(run_kiss_matcher
+    PUBLIC
+    ${PCL_INCLUDE_DIRS}
+)
+
+target_link_libraries(run_kiss_matcher
+    Eigen3::Eigen
+    TBB::tbb
+    kiss_matcher::kiss_matcher_core
+    robin::robin
+    ${PCL_LIBRARIES}
+)
+
 add_executable(registration_visualizer src/registration_visualizer.cpp)
 ament_target_dependencies(registration_visualizer
   rclcpp
@@ -44,6 +63,7 @@ target_link_libraries(registration_visualizer
 
 install(TARGETS
   registration_visualizer
+  run_kiss_matcher
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 project(kiss_matcher_ros)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 cmake_policy(SET CMP0074 NEW)
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_matcher/ AND NOT IS_SYMLINK ${CMAKE_CURRENT_SOURCE_DIR})

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -14,6 +14,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 cmake_policy(SET CMP0074 NEW)
 
+option(USE_ADDRESS_SANITIZER "Use address sanitizer" OFF)
+if (USE_ADDRESS_SANITIZER)
+    add_compile_options(-fsanitize=address -fsanitize-recover=address)
+    add_link_options(-fsanitize=address -fsanitize-recover=address)
+endif()
+
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_matcher/ AND NOT IS_SYMLINK ${CMAKE_CURRENT_SOURCE_DIR})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_matcher ${CMAKE_CURRENT_BINARY_DIR}/kiss_matcher)
 else()

--- a/ros/CMakeLists.txt
+++ b/ros/CMakeLists.txt
@@ -3,14 +3,26 @@ project(kiss_matcher_ros)
 
 cmake_policy(SET CMP0074 NEW)
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_matcher/ AND NOT IS_SYMLINK ${CMAKE_CURRENT_SOURCE_DIR})
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../cpp/kiss_matcher ${CMAKE_CURRENT_BINARY_DIR}/kiss_matcher)
+else()
+  #This is what kiss_icp does.
+    #cmake_minimum_required(VERSION 3.18)
+    #message(STATUS "Performing out-of-tree build, fetching KISS-Matcher v${CMAKE_PROJECT_VERSION} Release from Github")
+    #include(FetchContent)
+    #FetchContent_Declare(
+    #  ext_kiss_matcher_core PREFIX kiss_matcher_core
+    #  URL https://github.com/PRBonn/kiss-matcher/archive/refs/tags/v${CMAKE_PROJECT_VERSION}.tar.gz SOURCE_SUBDIR
+    #      cpp/kiss_matcher)
+    #FetchContent_MakeAvailable(ext_kiss_matcher_core)
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(PCL REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(robin REQUIRED)
-find_package(kiss_matcher REQUIRED)
 
 add_executable(registration_visualizer src/registration_visualizer.cpp)
 ament_target_dependencies(registration_visualizer
@@ -19,8 +31,6 @@ ament_target_dependencies(registration_visualizer
   pcl_conversions
   PCL
   Eigen3
-  robin
-  kiss_matcher
 )
 target_link_libraries(registration_visualizer
   Eigen3::Eigen

--- a/ros/package.xml
+++ b/ros/package.xml
@@ -10,6 +10,7 @@
   <depend>sensor_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
+  <depend>tf2_ros</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros/src/run_kiss_matcher.cpp
+++ b/ros/src/run_kiss_matcher.cpp
@@ -1,0 +1,173 @@
+#include <filesystem>
+
+#include <kiss_matcher/FasterPFH.hpp>
+#include <kiss_matcher/GncSolver.hpp>
+#include <kiss_matcher/KISSMatcher.hpp>
+#include <pcl/filters/filter.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/common/transforms.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/visualization/pcl_visualizer.h>
+
+//#include "quatro/quatro_utils.h"
+void colorize(const pcl::PointCloud<pcl::PointXYZ> &pc,
+              pcl::PointCloud<pcl::PointXYZRGB> &pc_colored,
+              const std::vector<int> &color) {
+  int N = pc.points.size();
+
+  pc_colored.clear();
+  pcl::PointXYZRGB pt_tmp;
+  for (int i = 0; i < N; ++i) {
+    const auto &pt = pc.points[i];
+    pt_tmp.x       = pt.x;
+    pt_tmp.y       = pt.y;
+    pt_tmp.z       = pt.z;
+    pt_tmp.r       = color[0];
+    pt_tmp.g       = color[1];
+    pt_tmp.b       = color[2];
+    pc_colored.points.emplace_back(pt_tmp);
+  }
+}
+
+std::vector<Eigen::Vector3f> convertCloudToVec(const pcl::PointCloud<pcl::PointXYZ>& cloud) {
+  std::vector<Eigen::Vector3f> vec;
+  vec.reserve(cloud.size());
+  for (const auto& pt : cloud.points) {
+    if (!std::isfinite(pt.x) || !std::isfinite(pt.y) || !std::isfinite(pt.z)) continue;
+    vec.emplace_back(pt.x, pt.y, pt.z);
+  }
+  return vec;
+}
+
+int main(int argc, char** argv) {
+  if (argc < 4) {
+    std::cerr << "Usage: " << argv[0]
+              << " <src_pcd_file> <tgt_pcd_file> <resolution> <yaw_aug_angle> <roll_aug_angle>" << std::endl;
+    return -1;
+  }
+  pcl::PointCloud<pcl::PointXYZ>::Ptr src_pcl(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr tgt_pcl(new pcl::PointCloud<pcl::PointXYZ>);
+
+  const std::string src_path = argv[1];
+  const std::string tgt_path = argv[2];
+  const float resolution     = std::stof(argv[3]);
+
+  Eigen::Matrix4f yaw_transform = Eigen::Matrix4f::Identity();
+  if (argc > 4) {
+    float yaw_aug_angle = std::stof(argv[4]);             // Yaw angle in degrees
+    float yaw_rad       = yaw_aug_angle * M_PI / 180.0f;  // Convert to radians
+
+    yaw_transform(0, 0) = std::cos(yaw_rad);
+    yaw_transform(0, 1) = -std::sin(yaw_rad);
+    yaw_transform(1, 0) = std::sin(yaw_rad);
+    yaw_transform(1, 1) = std::cos(yaw_rad);
+  }
+
+  Eigen::Matrix4f roll_transform = Eigen::Matrix4f::Identity();
+  if (argc > 5) {
+    float roll_aug_angle = std::stof(argv[5]);             // Yaw angle in degrees
+    float roll_rad       = roll_aug_angle * M_PI / 180.0f;  // Convert to radians
+
+    roll_transform(1, 1) = std::cos(roll_rad);
+    roll_transform(1, 2) = -std::sin(roll_rad);
+    roll_transform(2, 1) = std::sin(roll_rad);
+    roll_transform(2, 2) = std::cos(roll_rad);
+  }
+
+  Eigen::Matrix4f rotation_transform = yaw_transform * roll_transform;
+
+  std::cout << "Source input: " << src_path << "\n";
+  std::cout << "Target input: " << tgt_path << "\n";
+  int src_load_result = pcl::io::loadPCDFile<pcl::PointXYZ>(src_path, *src_pcl);
+  int tgt_load_result = pcl::io::loadPCDFile<pcl::PointXYZ>(tgt_path, *tgt_pcl);
+
+  std::vector<int> src_indices;
+  std::vector<int> tgt_indices;
+  pcl::removeNaNFromPointCloud(*src_pcl, *src_pcl, src_indices);
+  pcl::removeNaNFromPointCloud(*tgt_pcl, *tgt_pcl, tgt_indices);
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr rotated_src_pcl(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::transformPointCloud(*src_pcl, *rotated_src_pcl, rotation_transform);
+  src_pcl = rotated_src_pcl;
+
+  const auto& src_vec = convertCloudToVec(*src_pcl);
+  const auto& tgt_vec = convertCloudToVec(*tgt_pcl);
+
+  std::cout << "\033[1;32mLoad complete!\033[0m\n";
+
+  kiss_matcher::KISSMatcherConfig config = kiss_matcher::KISSMatcherConfig(resolution);
+  // NOTE(hlim): Two important parameters for enhancing performance
+  // 1. `config.use_quatro_ (default: false)`
+  // If the rotation is predominantly around the yaw axis, set `use_quatro_` to true like:
+  // config.use_quatro_ = true;
+  // Otherwise, the default mode activates SO(3)-based GNC.
+  // E.g., in the case of `VBR-Collosseo`, it should be set as `false`.
+  //
+  // 2. `config.use_ratio_test_ (default: true)`
+  // If dealing with a scan-level point cloud, the impact of `use_ratio_test_` is insignificant.
+  // Plus, setting `use_ratio_test_` to false helps speed up slightly
+  // If you want to try your own scan at a scan-level or loop closing situation,
+  // setting `false` boosts the inference speed.
+  // config.use_ratio_test_ = false;
+  kiss_matcher::KISSMatcher matcher(config);
+
+  const auto solution = matcher.estimate(src_vec, tgt_vec);
+
+  // Visualization
+  pcl::PointCloud<pcl::PointXYZ> src_viz = *src_pcl;
+  pcl::PointCloud<pcl::PointXYZ> tgt_viz = *tgt_pcl;
+  pcl::PointCloud<pcl::PointXYZ> est_viz;
+
+  Eigen::Matrix4f solution_eigen      = Eigen::Matrix4f::Identity();
+  solution_eigen.block<3, 3>(0, 0)    = solution.rotation.cast<float>();
+  solution_eigen.topRightCorner(3, 1) = solution.translation.cast<float>();
+
+  matcher.print();
+
+  size_t num_rot_inliers   = matcher.getNumRotationInliers();
+  size_t num_final_inliers = matcher.getNumFinalInliers();
+
+  // NOTE(hlim): By checking the final inliers, we can determine whether
+  // the registration was successful or not. The larger the threshold,
+  // the more conservatively the decision is made.
+  // See https://github.com/MIT-SPARK/KISS-Matcher/issues/24
+  size_t thres_num_inliers = 5;
+  if (num_final_inliers < thres_num_inliers) {
+    std::cout << "\033[1;33m=> Registration might have failed :(\033[0m\n";
+  } else {
+    std::cout << "\033[1;32m=> Registration likely succeeded XD\033[0m\n";
+  }
+
+  std::cout << solution_eigen << std::endl;
+  std::cout << "=====================================" << std::endl;
+
+  // ------------------------------------------------------------
+  // Save warped source cloud
+  // ------------------------------------------------------------
+  pcl::PointCloud<pcl::PointXYZ>::Ptr est_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::transformPointCloud(*src_pcl, *est_cloud, solution_eigen);
+  std::filesystem::path src_file_path(src_path);
+  std::string warped_pcd_filename =
+      src_file_path.parent_path().string() + "/" + src_file_path.stem().string() + "_warped.pcd";
+  pcl::io::savePCDFileASCII(warped_pcd_filename, *est_cloud);
+  std::cout << "Saved transformed source point cloud to: " << warped_pcd_filename << std::endl;
+
+  // ------------------------------------------------------------
+  // Visualization
+  // ------------------------------------------------------------
+  pcl::transformPointCloud(src_viz, est_viz, solution_eigen);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr src_colored(new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr tgt_colored(new pcl::PointCloud<pcl::PointXYZRGB>);
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr est_q_colored(new pcl::PointCloud<pcl::PointXYZRGB>);
+
+  colorize(src_viz, *src_colored, {195, 195, 195});
+  colorize(tgt_viz, *tgt_colored, {89, 167, 230});
+  colorize(est_viz, *est_q_colored, {238, 160, 61});
+
+  pcl::visualization::PCLVisualizer viewer1("Simple Cloud Viewer");
+  viewer1.addPointCloud<pcl::PointXYZRGB>(src_colored, "src_red");
+  viewer1.addPointCloud<pcl::PointXYZRGB>(tgt_colored, "tgt_green");
+  viewer1.addPointCloud<pcl::PointXYZRGB>(est_q_colored, "est_q_blue");
+
+  viewer1.spin();
+}

--- a/ros/src/run_kiss_matcher.cpp
+++ b/ros/src/run_kiss_matcher.cpp
@@ -74,6 +74,11 @@ int main(int argc, char** argv) {
     roll_transform(2, 2) = std::cos(roll_rad);
   }
 
+  ssize_t stress = 0;
+  if (argc > 6) {
+    stress = std::stoi(argv[6]);  // Number of stress iterations
+  }
+
   Eigen::Matrix4f rotation_transform = yaw_transform * roll_transform;
 
   std::cout << "Source input: " << src_path << "\n";
@@ -109,9 +114,17 @@ int main(int argc, char** argv) {
   // If you want to try your own scan at a scan-level or loop closing situation,
   // setting `false` boosts the inference speed.
   // config.use_ratio_test_ = false;
-  kiss_matcher::KISSMatcher matcher(config);
 
-  const auto solution = matcher.estimate(src_vec, tgt_vec);
+  kiss_matcher::KISSMatcher matcher(config);
+  kiss_matcher::RegistrationSolution solution;
+  solution = matcher.estimate(src_vec, tgt_vec);
+  for (int i = 1; i < stress; i++) {
+    matcher.clear();
+    matcher.reset();
+    matcher.resetSolver();
+    solution = matcher.estimate(src_vec, tgt_vec);
+    std::cout << "stress iteration:" << i << std::endl;
+  }
 
   // Visualization
   pcl::PointCloud<pcl::PointXYZ> src_viz = *src_pcl;


### PR DESCRIPTION
I was exploring and decided to help fix some warnings.  I note that newer versions of nanoflann fix the templates so that you can better choose the type that is used to store indexes.   I changed it from size_t to uint32_t in this pull request.  That may save some memory.
I also got brought run_kiss_matcher.cpp into kiss_matcher_ros.
Some of these changes may be useful to you.
I tried to keep them isolated and logical.