### PR TITLE
Add `<depend>gtsam</depend>` to package.xml for Dependency Management

### DIFF
--- a/ros/package.xml
+++ b/ros/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2_sensor_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>pcl_conversions</depend>
+  <depend>gtsam</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This PR adds `<depend>gtsam</depend>` to the package.xml file to declare GTSAM as a dependency for the `kiss_matcher_ros` package.

GTSAM is officially released for ROS, as documented here: [https://index.ros.org/p/gtsam/](https://index.ros.org/p/gtsam/). By including this dependency, users can now easily install GTSAM using the following command:

```bash
rosdep install -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
```

This eliminates the need for manually compiling and installing GTSAM, as well as resolving Eigen version compatibility issues.