### PR TITLE
Fix PCL Viewer Escaping

### DIFF
--- a/cpp/examples/src/run_kiss_matcher.cc
+++ b/cpp/examples/src/run_kiss_matcher.cc
@@ -183,6 +183,6 @@ int main(int argc, char** argv) {
   viewer1.addPointCloud<pcl::PointXYZRGB>(est_q_colored, "est_q_blue");
 
   while (!viewer1.wasStopped()) {
-    viewer1.spinOnce();
+    viewer1.spin();
   }
 }

--- a/cpp/examples/src/run_matching_using_bunny.cc
+++ b/cpp/examples/src/run_matching_using_bunny.cc
@@ -148,6 +148,6 @@ int main() {
   viewer1.addPointCloud<pcl::PointXYZRGB>(est_t_colored, "est_t_magenta");
 
   while (!viewer1.wasStopped()) {
-    viewer1.spinOnce();
+    viewer1.spin();
   }
 }


### PR DESCRIPTION
The SpinOnce() method being called automatically closes the visualization window. This doesn't completely fix the segfault issue, however.