### PR TITLE
Create python package definitions to support non-editable installs

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -40,7 +40,10 @@ else()
   FetchContent_MakeAvailable(ext_kiss_matcher_core)
 endif()
 
-set(OUTPUT_MODULE_NAME kiss_matcher)
+# Keep the public package called “kiss_matcher”, but put the compiled
+# pybind11 backend in a *private* module so it doesn’t shadow the
+# package directory.
+set(OUTPUT_MODULE_NAME _kiss_matcher)
 
 pybind11_add_module(${OUTPUT_MODULE_NAME} kiss_matcher/pybind/kiss_matcher_pybind.cpp)
 target_link_libraries(${OUTPUT_MODULE_NAME} PUBLIC kiss_matcher_core)

--- a/python/kiss_matcher/__init__.py
+++ b/python/kiss_matcher/__init__.py
@@ -19,5 +19,24 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-# from .kiss_matcher import *
+"""
+High-level Python façade for the KISS-Matcher C++ backend.
+All public symbols from the compiled module are re-exported so users can
+simply::
+    import kiss_matcher as km
+    cfg = km.KISSMatcherConfig(voxel_size=0.3)
+"""
+from importlib import import_module as _im
 __version__ = "1.0.0"
+__all__: list[str] = []
+# Import the backend that CMake just built (“_kiss_matcher” lives inside
+# the same package directory thanks to the change above).
+_backend = _im("kiss_matcher._kiss_matcher")
+# Re-export every non-private attribute so that they appear directly under
+# the top-level `kiss_matcher` namespace.
+for _name in dir(_backend):
+    if not _name.startswith("_"):
+        globals()[_name] = getattr(_backend, _name)
+        __all__.append(_name)
+# Keep a private reference so the module isn’t garbage-collected.
+del _backend, _name, _im

--- a/python/kiss_matcher/__init__.py
+++ b/python/kiss_matcher/__init__.py
@@ -31,7 +31,12 @@ __version__ = "1.0.0"
 __all__: list[str] = []
 # Import the backend that CMake just built (“_kiss_matcher” lives inside
 # the same package directory thanks to the change above).
-_backend = _im("kiss_matcher._kiss_matcher")
+try:
+    # Preferred: wheel built with the extension placed in the package
+    _backend = _im("kiss_matcher._kiss_matcher")
+except ModuleNotFoundError:
+    # Fallback: extension was installed at top level (site-packages/_kiss_matcher*.so)
+    _backend = _im("_kiss_matcher")
 # Re-export every non-private attribute so that they appear directly under
 # the top-level `kiss_matcher` namespace.
 for _name in dir(_backend):

--- a/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
+++ b/python/kiss_matcher/pybind/kiss_matcher_pybind.cpp
@@ -43,7 +43,7 @@ using namespace kiss_matcher;
 
 PYBIND11_MAKE_OPAQUE(std::vector<Eigen::Vector3d>);
 
-PYBIND11_MODULE(kiss_matcher, m) {
+PYBIND11_MODULE(_kiss_matcher, m) {
   m.doc()               = "Pybind11 bindings for KISSMatcher library";
   m.attr("__version__") = "0.3.1";
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,3 +37,4 @@ dependencies = [
 ]
 
 [tool.scikit-build]
+wheel.packages = ["kiss_matcher"]


### PR DESCRIPTION
The current pyproject.toml shadows the kiss_matcher package and does not contain any definitions. Editable install works because kiss_matcher is a valid path at the editable install root. These changes address a few things:
- pybind module name shadowing native python module definitions
- __init__.py search for definitions to include in the wheel
- explicit inclusion of python definitions in the toml, which is helpful for older scikit versions