### PR TITLE
Set tbb cmake file more rigorous against various CMake version

### DIFF
--- a/cpp/kiss_matcher/3rdparty/tbb/tbb.cmake
+++ b/cpp/kiss_matcher/3rdparty/tbb/tbb.cmake
@@ -30,15 +30,33 @@ option(TBB_TEST "TBB TBB_TEST" OFF)
 include(FetchContent)
 FetchContent_Declare(tbb URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2022.0.0.tar.gz)
 FetchContent_GetProperties(tbb)
-if(NOT tbb_POPULATED)
-  FetchContent_Populate(tbb)
-  if(${CMAKE_VERSION} GREATER_EQUAL 3.25)
-    add_subdirectory(${tbb_SOURCE_DIR} ${tbb_BINARY_DIR} SYSTEM EXCLUDE_FROM_ALL)
-  else()
-    # Emulate the SYSTEM flag introduced in CMake 3.25. Withouth this flag the compiler will
-    # consider this 3rdparty headers as source code and fail due the -Werror flag.
+# Prefer FetchContent_MakeAvailable when available (CMake 3.14+)
+if(COMMAND FetchContent_MakeAvailable)
+  FetchContent_MakeAvailable(tbb)
+
+  # Mark TBB's include dirs as 'SYSTEM' to ignore third-party warnings
+  get_target_property(_tbb_inc tbb INTERFACE_INCLUDE_DIRECTORIES)
+  if(_tbb_inc)
+    set_target_properties(tbb PROPERTIES
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_tbb_inc}")
+  endif()
+
+# Fallback for older/special environments: Populate + add_subdirectory
+else()
+  # On CMake 3.30+, suppress CMP0169 warning for FetchContent_Populate by setting it to OLD
+  if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+  endif()
+
+  FetchContent_GetProperties(tbb)
+  if(NOT tbb_POPULATED)
+    FetchContent_Populate(tbb)
+    # Before 3.25 there is no SYSTEM option, so set system includes manually
     add_subdirectory(${tbb_SOURCE_DIR} ${tbb_BINARY_DIR} EXCLUDE_FROM_ALL)
-    get_target_property(tbb_include_dirs tbb INTERFACE_INCLUDE_DIRECTORIES)
-    set_target_properties(tbb PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${tbb_include_dirs}")
+    get_target_property(_tbb_inc tbb INTERFACE_INCLUDE_DIRECTORIES)
+    if(_tbb_inc)
+      set_target_properties(tbb PROPERTIES
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_tbb_inc}")
+    endif()
   endif()
 endif()


### PR DESCRIPTION
To fix issue in #81. Now KISS-Matcher works both 3.22 and 3.31 versions of CMake.