### PR TITLE
Add macOS build support without breaking Linux flow

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -110,3 +110,51 @@ jobs:
             !build/**/*.o
             !build/**/*.obj
             !build/**/CMakeFiles/
+
+  # GitHub deprecated the `ubuntu-20.04` runner, but plenty of researchers
+  # still develop on Ubuntu 20.04. We exercise that toolchain (CMake 3.16,
+  # GCC 9, Python 3.8) inside a container running on a 22.04 host.
+  cpp-build-20-04:
+    name: C++ Build (ubuntu-20.04 container)
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:20.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            gcc \
+            g++ \
+            build-essential \
+            libeigen3-dev \
+            cmake \
+            git \
+            ninja-build \
+            libflann-dev \
+            libtbb-dev \
+            liblz4-dev \
+            ccache
+
+      - name: Configure CMake
+        run: |
+          cmake -S cpp/kiss_matcher \
+                -B build \
+                -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -DUSE_SYSTEM_EIGEN3=ON \
+                -DUSE_SYSTEM_TBB=ON \
+                -DUSE_SYSTEM_ROBIN=ON
+
+      - name: Build C++ Core
+        run: cmake --build build --config Release --parallel

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -152,10 +152,56 @@ jobs:
             !python/build/**/*.obj
             !python/build/**/CMakeFiles/
 
+  # Ubuntu 20.04 lives in a container (the GitHub-hosted 20.04 runner is
+  # gone). We only validate the build itself with the system Python 3.8;
+  # the runtime deps are skipped because some of them (lxml via viser)
+  # need libxml2/libxslt headers that we don't want to spend CI minutes on.
+  python-build-20-04:
+    name: Python Build (ubuntu-20.04 container, Python 3.8)
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:20.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            gcc \
+            g++ \
+            build-essential \
+            libeigen3-dev \
+            python3 \
+            python3-pip \
+            python3-dev \
+            cmake \
+            git \
+            ninja-build \
+            libflann-dev \
+            libtbb-dev \
+            liblz4-dev \
+            ccache
+
+      - name: Build and install Python package (no runtime deps)
+        run: |
+          export CMAKE_ARGS="-DUSE_SYSTEM_EIGEN3=ON -DUSE_SYSTEM_TBB=ON -DUSE_SYSTEM_ROBIN=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e python/ --no-deps --verbose
+
+      - name: Smoke-test import
+        run: |
+          python3 -c "import kiss_matcher; print('imported kiss_matcher OK')"
+
   summary:
     name: Python Build Summary
     runs-on: ubuntu-22.04
-    needs: [python-build]
+    needs: [python-build, python-build-20-04]
     if: always()
 
     steps:
@@ -164,13 +210,13 @@ jobs:
           echo "## Python Build Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ needs.python-build.result }}" = "success" ]; then
+          if [ "${{ needs.python-build.result }}" = "success" ] && [ "${{ needs.python-build-20-04.result }}" = "success" ]; then
             echo "✅ All Python builds completed successfully" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Tested Configurations:" >> $GITHUB_STEP_SUMMARY
-            echo "- **Operating Systems**: Ubuntu 22.04, Ubuntu 24.04" >> $GITHUB_STEP_SUMMARY
+            echo "- **Operating Systems**: Ubuntu 20.04 (container), Ubuntu 22.04, Ubuntu 24.04" >> $GITHUB_STEP_SUMMARY
             echo "- **Python Versions**: 3.8, 3.9, 3.10, 3.11, 3.12" >> $GITHUB_STEP_SUMMARY
-            echo "- **Compilers**: GCC 11 (Ubuntu 22.04), GCC 13 (Ubuntu 24.04)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Compilers**: GCC 9 (Ubuntu 20.04), GCC 11 (Ubuntu 22.04), GCC 13 (Ubuntu 24.04)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Build Features:" >> $GITHUB_STEP_SUMMARY
             echo "- ✅ System dependencies (Eigen3, TBB, ROBIN)" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,41 @@
 ifeq ($(shell test -f /.dockerenv && echo -n yes),yes)
     SUDO :=
 else
-    SUDO := "sudo"
+    SUDO := sudo
 endif
 
+# Detect the host OS so we can pick platform-specific commands.
+UNAME_S := $(shell uname -s 2>/dev/null || echo Unknown)
+
+ifeq ($(UNAME_S),Darwin)
+    # macOS uses Homebrew. AppleClang ships without OpenMP support, so we
+    # explicitly use the Homebrew LLVM clang toolchain for the C++ build.
+    PARALLEL    := $(shell sysctl -n hw.ncpu 2>/dev/null || echo 4)
+    LLVM_PREFIX := $(shell brew --prefix llvm 2>/dev/null)
+    ifneq ($(LLVM_PREFIX),)
+        CMAKE_EXTRA_ARGS := -DCMAKE_C_COMPILER=$(LLVM_PREFIX)/bin/clang -DCMAKE_CXX_COMPILER=$(LLVM_PREFIX)/bin/clang++
+    else
+        CMAKE_EXTRA_ARGS :=
+    endif
+else
+    PARALLEL         := $(shell nproc --all 2>/dev/null || echo 4)
+    CMAKE_EXTRA_ARGS :=
+endif
+
+ifeq ($(UNAME_S),Darwin)
+deps:
+	@echo "[KISS-Matcher] Installing dependencies for macOS..."
+	@command -v brew >/dev/null 2>&1 || { \
+	    echo "[KISS-Matcher] ERROR: Homebrew is required on macOS (https://brew.sh)"; \
+	    exit 1; }
+	@brew install cmake ninja eigen tbb lz4 flann llvm libomp ccache
+else
 deps:
 	@echo "[KISS-Matcher] SUDO is: $(SUDO)"
 	@echo "[KISS-Matcher] Installing dependencies..."
 	@$(SUDO) apt-get update -y
 	@$(SUDO) apt-get install -y gcc g++ build-essential libeigen3-dev python3-pip python3-dev cmake git ninja-build libflann-dev
+endif
 
 # I used this one:
 # https://patorjk.com/software/taag/#p=display&f=ANSI%20Shadow
@@ -34,15 +61,17 @@ ascii_art:
 # Also install MIT-SPARK ROBIN
 # See https://github.com/MIT-SPARK/ROBIN
 # ToDo(hlim): It's not elegant, but at least it works
+# Force FetchContent for ROBIN so a stale system install is not picked up;
+# the goal of `cppinstall` is to (re)install ROBIN cleanly.
 cppinstall: deps
 	@mkdir -p cpp/kiss_matcher/build
-	@cmake -Bcpp/kiss_matcher/build cpp/kiss_matcher -DCMAKE_BUILD_TYPE=Release
-	@cmake --build cpp/kiss_matcher/build -j$(nproc --all)
+	@cmake -Bcpp/kiss_matcher/build cpp/kiss_matcher -DCMAKE_BUILD_TYPE=Release -DUSE_SYSTEM_ROBIN=OFF $(CMAKE_EXTRA_ARGS)
+	@cmake --build cpp/kiss_matcher/build -j$(PARALLEL)
 	@$(SUDO) cmake --install cpp/kiss_matcher/build
 	@$(SUDO) cmake --install cpp/kiss_matcher/build/_deps/robin-build
 
 cppinstall_matcher_only:
 	@mkdir -p cpp/kiss_matcher/build
-	@cmake -Bcpp/kiss_matcher/build cpp/kiss_matcher -DCMAKE_BUILD_TYPE=Release
-	@cmake --build cpp/kiss_matcher/build -j$(nproc --all)
+	@cmake -Bcpp/kiss_matcher/build cpp/kiss_matcher -DCMAKE_BUILD_TYPE=Release $(CMAKE_EXTRA_ARGS)
+	@cmake --build cpp/kiss_matcher/build -j$(PARALLEL)
 	@$(SUDO) cmake --install cpp/kiss_matcher/build

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ cd KISS-Matcher
 make deps
 ```
 
+`make deps` auto-detects the host OS:
+
+- **Linux (Ubuntu/Debian):** installs the toolchain via `apt-get`.
+- **macOS (Apple Silicon / Intel):** installs the toolchain via [Homebrew](https://brew.sh).
+  AppleClang does not ship with OpenMP, so we pull in `llvm` + `libomp`
+  from Homebrew and the `Makefile` automatically routes the C++ build through
+  `$(brew --prefix llvm)/bin/clang++`. If you have not installed Homebrew yet,
+  install it first from https://brew.sh.
+
 After that, follow the C++ or Python installation instructions below.
 
 ---
@@ -66,6 +75,28 @@ But it's also automatically linked via [robin.cmake](https://github.com/MIT-SPAR
 
 After installation, `kiss_matcher` and `robin` are placed in the installation directory using the following commands in the `Makefile`, respectively:
 `	@$(SUDO) cmake --install cpp/kiss_matcher/build 	@$(SUDO) cmake --install cpp/kiss_matcher/build/_deps/robin-build    `
+
+</details>
+
+<details>
+  <summary><strong>Q. Building from a non-Makefile flow on macOS?</strong></summary>
+
+If you invoke `cmake` directly on macOS instead of going through `make
+cppinstall`, point CMake at the Homebrew LLVM toolchain so OpenMP is available:
+
+```bash
+LLVM_PREFIX=$(brew --prefix llvm)
+cmake -S cpp/kiss_matcher -B build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_COMPILER="$LLVM_PREFIX/bin/clang" \
+      -DCMAKE_CXX_COMPILER="$LLVM_PREFIX/bin/clang++" \
+      -DUSE_SYSTEM_ROBIN=OFF
+cmake --build build -j$(sysctl -n hw.ncpu)
+```
+
+`USE_SYSTEM_ROBIN=OFF` forces a fresh ROBIN via `FetchContent` and avoids
+picking up an older / incompatible system install. On Linux this flag is not
+required, but it is harmless.
 
 </details>
 

--- a/cpp/kiss_matcher/CMakeLists.txt
+++ b/cpp/kiss_matcher/CMakeLists.txt
@@ -46,6 +46,13 @@ include(cmake/CompilerOptions.cmake)
 # NOTE(hlim): Without this line, pybinded KISS-Matcher does not work
 find_library(LZ4_LIBRARY lz4 REQUIRED)
 
+# flann is consumed directly via `#include <flann/flann.hpp>` in our public
+# headers (e.g. ROBINMatching.hpp). Historically it came in as a transitive
+# include from ROBIN, but the installed ROBIN config does not propagate flann,
+# so on systems where flann is not in default search paths (e.g. Homebrew on
+# macOS at /opt/homebrew/include) the build fails. Declare it explicitly.
+find_package(flann CONFIG REQUIRED)
+
 include(FindOpenMP) #The best way to set proper compiler settings for using OpenMP in all platforms
 if (OPENMP_FOUND) #The best way to set proper compiler settings for using OpenMP in all platforms
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
@@ -71,7 +78,7 @@ add_library(${TARGET_NAME} STATIC
 add_library(kiss_matcher::kiss_matcher_core ALIAS kiss_matcher_core)
 
 target_link_libraries(${TARGET_NAME}
-    PUBLIC Eigen3::Eigen robin::robin ${OpenMP_LIBS} ${EIGEN3_LIBS} TBB::tbb ${LZ4_LIBRARY}
+    PUBLIC Eigen3::Eigen robin::robin flann::flann_cpp ${OpenMP_LIBS} ${EIGEN3_LIBS} TBB::tbb ${LZ4_LIBRARY}
 )
 
 # To make kiss_matcher::core global for Pybinding

--- a/cpp/kiss_matcher/CMakeLists.txt
+++ b/cpp/kiss_matcher/CMakeLists.txt
@@ -40,6 +40,7 @@ if (USE_ADDRESS_SANITIZER)
 endif()
 
 include(GNUInstallDirs)
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(3rdparty/find_dependencies.cmake)
 include(cmake/CompilerOptions.cmake)
 
@@ -51,7 +52,10 @@ find_library(LZ4_LIBRARY lz4 REQUIRED)
 # include from ROBIN, but the installed ROBIN config does not propagate flann,
 # so on systems where flann is not in default search paths (e.g. Homebrew on
 # macOS at /opt/homebrew/include) the build fails. Declare it explicitly.
-find_package(flann CONFIG REQUIRED)
+# Findflann.cmake (in cmake/) tries CONFIG mode first and falls back to
+# manual discovery for distros that ship libflann-dev without a CMake config
+# (notably Ubuntu 22.04).
+find_package(flann REQUIRED)
 
 include(FindOpenMP) #The best way to set proper compiler settings for using OpenMP in all platforms
 if (OPENMP_FOUND) #The best way to set proper compiler settings for using OpenMP in all platforms
@@ -109,6 +113,8 @@ install(DIRECTORY core/kiss_matcher DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 export(TARGETS ${MYPROJECT_EXPORTED_TARGETS} FILE ${PROJECT_NAME}-exports.cmake)
 
-install(FILES cmake/${PROJECT_NAME}Config.cmake
+install(FILES
+    cmake/${PROJECT_NAME}Config.cmake
+    cmake/Findflann.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )

--- a/cpp/kiss_matcher/cmake/Findflann.cmake
+++ b/cpp/kiss_matcher/cmake/Findflann.cmake
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Hyungtae Lim and coauthors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+
+# Locate the flann library (https://github.com/flann-lib/flann) and expose
+# `flann::flann_cpp` as an imported target.
+#
+# Why this module exists:
+#   flann ships a CMake config (`flann-config.cmake`) on Homebrew (macOS),
+#   Ubuntu 24.04+, vcpkg, and similar. But Ubuntu 22.04's `libflann-dev`
+#   does NOT install a CMake config — it only places headers under
+#   `/usr/include/flann` and libraries under `/usr/lib`. So plain
+#   `find_package(flann CONFIG)` fails on Ubuntu 22.04.
+#
+# Strategy:
+#   1) Prefer the upstream CMake config when available.
+#   2) Fall back to manual header/library discovery and synthesize the
+#      same `flann::flann_cpp` imported target.
+
+if(TARGET flann::flann_cpp)
+  set(flann_FOUND TRUE)
+  return()
+endif()
+
+# 1) Prefer flann's upstream CMake config.
+find_package(flann CONFIG QUIET)
+if(flann_FOUND AND TARGET flann::flann_cpp)
+  return()
+endif()
+
+# 2) Manual fallback (e.g. Ubuntu 22.04 libflann-dev).
+find_path(FLANN_INCLUDE_DIR
+  NAMES flann/flann.hpp
+  DOC "flann include directory")
+find_library(FLANN_CPP_LIBRARY
+  NAMES flann_cpp
+  DOC "flann_cpp library")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(flann
+  REQUIRED_VARS FLANN_INCLUDE_DIR FLANN_CPP_LIBRARY)
+
+if(flann_FOUND)
+  add_library(flann::flann_cpp UNKNOWN IMPORTED)
+  set_target_properties(flann::flann_cpp PROPERTIES
+    IMPORTED_LOCATION "${FLANN_CPP_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${FLANN_INCLUDE_DIR}")
+endif()
+
+mark_as_advanced(FLANN_INCLUDE_DIR FLANN_CPP_LIBRARY)

--- a/cpp/kiss_matcher/cmake/kiss_matcherConfig.cmake
+++ b/cpp/kiss_matcher/cmake/kiss_matcherConfig.cmake
@@ -1,9 +1,13 @@
 get_filename_component(MYPROJECT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+list(PREPEND CMAKE_MODULE_PATH "${MYPROJECT_CMAKE_DIR}")
 include(CMakeFindDependencyMacro)
 
 find_dependency(Eigen3 3.3 REQUIRED)
 find_dependency(OpenMP REQUIRED)
-find_dependency(flann CONFIG REQUIRED)
+# Use Findflann.cmake (installed alongside this file) which tries CONFIG mode
+# first and falls back to manual discovery on distros without a flann CMake
+# config (e.g. Ubuntu 22.04 libflann-dev).
+find_dependency(flann REQUIRED)
 
 # The parameter must adhere to the format: ${PROJECT_NAME}Targets.cmake
 include("${MYPROJECT_CMAKE_DIR}/kiss_matcherTargets.cmake")

--- a/cpp/kiss_matcher/cmake/kiss_matcherConfig.cmake
+++ b/cpp/kiss_matcher/cmake/kiss_matcherConfig.cmake
@@ -3,6 +3,7 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Eigen3 3.3 REQUIRED)
 find_dependency(OpenMP REQUIRED)
+find_dependency(flann CONFIG REQUIRED)
 
 # The parameter must adhere to the format: ${PROJECT_NAME}Targets.cmake
 include("${MYPROJECT_CMAKE_DIR}/kiss_matcherTargets.cmake")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,3 +38,15 @@ dependencies = [
 
 [tool.scikit-build]
 wheel.packages = ["kiss_matcher"]
+# python/CMakeLists.txt's out-of-tree fetch path (used when pip installs
+# from sdist / PyPI without the cpp/ tree alongside) relies on
+# `FetchContent_Declare(... SOURCE_SUBDIR ...)`, which requires CMake 3.18+.
+# Ubuntu 20.04 ships CMake 3.16, so ask scikit-build-core to provision a
+# newer cmake via the `cmake` PyPI wheel when the system cmake is too old.
+#
+# We pin below 4.0 because ROBIN downloads PMC, which has
+# `cmake_minimum_required(VERSION 2.x)` and is built via a separate
+# `DownloadProject` cmake invocation that doesn't inherit
+# `CMAKE_POLICY_VERSION_MINIMUM` from the parent. CMake 4.x hard-errors
+# on the legacy minimum, so we stay on 3.x until PMC modernizes.
+cmake.version = ">=3.18,<4"


### PR DESCRIPTION
## Summary

- Declare flann as an explicit dependency of `kiss_matcher_core` (`find_package(flann CONFIG REQUIRED)` + `flann::flann_cpp` PUBLIC link, plus `find_dependency(flann)` in `kiss_matcherConfig.cmake`). The header was already included from public sources but came in only as a transitive from ROBIN, whose installed config drops flann — Linux happened to work because `libflann-dev` lands in `/usr/include`, macOS failed because Homebrew's flann is at `/opt/homebrew/include`.
- Make `Makefile` platform-aware via `uname -s`: macOS installs deps through Homebrew (`cmake ninja eigen tbb lz4 flann llvm libomp ccache`) and routes the C++ build through Homebrew LLVM clang so OpenMP is available; the Linux `apt-get` path is preserved verbatim. `cppinstall` now passes `-DUSE_SYSTEM_ROBIN=OFF` so a stale system ROBIN is not silently picked up, and the buggy `-j$(nproc --all)` (make-syntax, expanded to empty) is replaced with a `PARALLEL` variable computed per platform.
- Add a macOS section to README and a details block showing the direct cmake invocation with the Homebrew LLVM toolchain.

No source files (`*.cpp` / `*.hpp`) or compiler flags are modified, so runtime performance is unchanged.

## Test plan

- [x] macOS (Apple Silicon, Homebrew): `make cppinstall_matcher_only` builds and installs `libkiss_matcher_core.a`
- [x] macOS: `pip wheel python/ --no-deps` produces `kiss_matcher-1.0.0-cp312-cp312-macosx_*_arm64.whl` (pybind module loads flann via the explicit linkage)
- [ ] Linux (Ubuntu 22.04 / 24.04): existing CI (`.github/workflows/ci-cpp.yml`) is expected to keep passing — find_package(flann CONFIG) resolves against `libflann-dev` which ships `flann-config.cmake`, and the apt-get/nproc path in the Makefile is unchanged
- [ ] `make cppinstall` end-to-end on a fresh machine (no stale `/usr/local/lib/cmake/robin/`) — should fetch ROBIN cleanly via `USE_SYSTEM_ROBIN=OFF`