### PR TITLE
Bump ROBIN dependency to v.1.2.7

### DIFF
--- a/cpp/kiss_matcher/3rdparty/robin/robin.cmake
+++ b/cpp/kiss_matcher/3rdparty/robin/robin.cmake
@@ -25,7 +25,7 @@
 option(PMC_BUILD_SHARED "Build pmc as a shared library (.so)" OFF)
 
 include(FetchContent)
-FetchContent_Declare(robin URL https://github.com/MIT-SPARK/ROBIN/archive/refs/tags/v.1.2.6.tar.gz)
+FetchContent_Declare(robin URL https://github.com/MIT-SPARK/ROBIN/archive/refs/tags/v.1.2.7.tar.gz)
 FetchContent_GetProperties(robin)
 
 # Prefer FetchContent_MakeAvailable when available (CMake 3.14+)


### PR DESCRIPTION
## Summary
- Bumps the FetchContent pin in \`cpp/kiss_matcher/3rdparty/robin/robin.cmake\` from \`v.1.2.6\` to \`v.1.2.7\`.
- v.1.2.7 ([MIT-SPARK/ROBIN#20](https://github.com/MIT-SPARK/ROBIN/pull/20)) pins PMC to [MIT-SPARK's fork](https://github.com/MIT-SPARK/pmc/tree/windows-compat) with Windows MSVC compatibility patches and re-greens ROBIN's manylinux wheel CI. For Linux/macOS — the only platforms KISS-Matcher itself currently builds on — the change is behavior-neutral.

## Why now
Prep step toward \`pip install kiss-matcher\` from PyPI. Bumping ROBIN ahead of any Windows-wheel work means we don't have to re-pin in the same PR that adds Windows support later.

## Test plan
- [x] Local macOS editable build (Homebrew LLVM): \`pip install -e python/\` succeeds, \`import kiss_matcher\` exposes \`KISSMatcher\`, \`KISSMatcherConfig\`, \`RegistrationSolution\`.
- [ ] CI: \`Python Build (ubuntu-22.04 / 24.04, Python 3.8-3.12)\`.
- [ ] CI: \`Python Build (macos-13/14, Python 3.10/3.12)\`.
- [ ] CI: \`C++ Build\` matrix.