### PR TITLE
ci: drop macos-13 from wheel matrix (queue stuck)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -38,11 +38,13 @@ jobs:
       matrix:
         # Linux wheels: manylinux x86_64 (cibuildwheel runs inside the
         #   container and yum-installs the system deps below).
-        # macOS: arm64 (macos-14) and x86_64 (macos-13) host-native builds
-        #   with the Homebrew LLVM toolchain (AppleClang has no OpenMP).
+        # macOS: arm64 only (macos-14). macos-13 (Intel) is intentionally
+        #   omitted — GitHub's macos-13 hosted runners are being phased out
+        #   and routinely sit in the queue for many hours, blocking the
+        #   release pipeline. Intel-Mac users can install from sdist.
         # Windows is not yet supported (ROBIN's src/pkc.cpp uses GCC builtin
         #   atomics + size_t OpenMP for indices that MSVC OpenMP 2.0 rejects).
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-22.04, macos-14]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Drops macos-13 from the cibuildwheel matrix so the v1.0.0 release pipeline can finish. The macos-13 wheel job has been queued for >13 hours due to GitHub-side runner capacity issues.

## Why drop instead of wait
- macos-13 hosted runners are being phased out by GitHub.
- macOS-14 (arm64) wheels still ship — Apple Silicon is the majority of new Macs.
- Intel-Mac users can still install via sdist: \`pip install kiss-matcher\` falls back to source build automatically when no matching wheel exists.

## Re-enable later
Once GitHub stabilizes \`macos-13\` capacity (or we move to \`macos-13-large\`, \`macos-15\` alternatives), re-add to the matrix.