### PR TITLE
ci: drop macos-13 from C++/Python build matrices

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -169,7 +169,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-13]
+        # macos-13 (Intel) is omitted: GitHub's hosted macos-13 runners are
+        # being phased out and queue for many hours, blocking CI. Apple
+        # Silicon (macos-14) covers the macOS path we actively ship.
+        os: [macos-14]
 
     # Homebrew on the macOS runners ships CMake 4.x, which hard-errors on
     # legacy `cmake_minimum_required(VERSION 2.x)` in transitive deps

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -208,7 +208,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-13]
+        # macos-13 (Intel) is omitted: GitHub's hosted macos-13 runners are
+        # being phased out and queue for many hours, blocking CI. Apple
+        # Silicon (macos-14) covers the macOS path we actively ship.
+        os: [macos-14]
         python-version: ['3.10', '3.12']
 
     # See ci-cpp.yml for why this env is set on the macOS jobs.
@@ -300,7 +303,7 @@ jobs:
             echo "✅ All Python builds completed successfully" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Tested Configurations:" >> $GITHUB_STEP_SUMMARY
-            echo "- **Operating Systems**: Ubuntu 20.04 (container), Ubuntu 22.04, Ubuntu 24.04, macOS 13 (Intel), macOS 14 (Apple Silicon)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Operating Systems**: Ubuntu 20.04 (container), Ubuntu 22.04, Ubuntu 24.04, macOS 14 (Apple Silicon)" >> $GITHUB_STEP_SUMMARY
             echo "- **Python Versions**: 3.8, 3.9, 3.10, 3.11, 3.12 (Linux); 3.10, 3.12 (macOS)" >> $GITHUB_STEP_SUMMARY
             echo "- **Compilers**: GCC 9 (Ubuntu 20.04), GCC 11 (Ubuntu 22.04), GCC 13 (Ubuntu 24.04), Homebrew LLVM clang (macOS)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Removes \`macos-13\` from the matrices in \`ci-cpp.yml\` and \`ci-python.yml\` (and the corresponding line in the Python build summary). All remaining macos-13 mentions in the workflows are now explanatory comments only.

## Why
GitHub's hosted \`macos-13\` runners are being phased out and routinely sit in the queue for many hours, blocking CI. PR #97 already dropped them from \`pypi-publish.yml\` for the same reason; this aligns the regular C++/Python build matrices.

## Scope
- macOS coverage now: \`macos-14\` (Apple Silicon) only — the only macOS wheel we ship anyway.
- Intel-Mac users keep the source-build path: \`pip install kiss-matcher\` falls back to sdist when no matching wheel exists.

## Test plan
- [ ] CI: matrix shrinks to \`macos-14\` only on PR #98.
- [ ] CI summary in Python build run no longer claims macOS 13 coverage.