### PR TITLE
ci: add macos-15 to C++/Python build matrices

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -170,9 +170,11 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 (Intel) is omitted: GitHub's hosted macos-13 runners are
-        # being phased out and queue for many hours, blocking CI. Apple
-        # Silicon (macos-14) covers the macOS path we actively ship.
-        os: [macos-14]
+        # being phased out and queue for many hours, blocking CI. macos-14
+        # is our minimum-supported Apple Silicon build (matches the wheel
+        # we publish); macos-15 catches regressions on the newest Xcode
+        # and Homebrew toolchain.
+        os: [macos-14, macos-15]
 
     # Homebrew on the macOS runners ships CMake 4.x, which hard-errors on
     # legacy `cmake_minimum_required(VERSION 2.x)` in transitive deps

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -209,9 +209,11 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 (Intel) is omitted: GitHub's hosted macos-13 runners are
-        # being phased out and queue for many hours, blocking CI. Apple
-        # Silicon (macos-14) covers the macOS path we actively ship.
-        os: [macos-14]
+        # being phased out and queue for many hours, blocking CI. macos-14
+        # is our minimum-supported Apple Silicon build (matches the wheel
+        # we publish); macos-15 catches regressions on the newest Xcode
+        # and Homebrew toolchain.
+        os: [macos-14, macos-15]
         python-version: ['3.10', '3.12']
 
     # See ci-cpp.yml for why this env is set on the macOS jobs.
@@ -303,7 +305,7 @@ jobs:
             echo "✅ All Python builds completed successfully" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Tested Configurations:" >> $GITHUB_STEP_SUMMARY
-            echo "- **Operating Systems**: Ubuntu 20.04 (container), Ubuntu 22.04, Ubuntu 24.04, macOS 14 (Apple Silicon)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Operating Systems**: Ubuntu 20.04 (container), Ubuntu 22.04, Ubuntu 24.04, macOS 14 + macOS 15 (Apple Silicon)" >> $GITHUB_STEP_SUMMARY
             echo "- **Python Versions**: 3.8, 3.9, 3.10, 3.11, 3.12 (Linux); 3.10, 3.12 (macOS)" >> $GITHUB_STEP_SUMMARY
             echo "- **Compilers**: GCC 9 (Ubuntu 20.04), GCC 11 (Ubuntu 22.04), GCC 13 (Ubuntu 24.04), Homebrew LLVM clang (macOS)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Adds \`macos-15\` to the matrices in \`ci-cpp.yml\` and \`ci-python.yml\`. \`macos-14\` stays as the minimum-supported Apple Silicon build (and matches the wheel we ship via \`pypi-publish.yml\`), while \`macos-15\` catches regressions on the newest Xcode + Homebrew toolchain.

## Why not also in pypi-publish.yml
Adding \`macos-15\` to the wheel matrix would just produce an arm64 wheel identical to macos-14's but with a stricter \`MACOSX_DEPLOYMENT_TARGET=15.0\`, locking out macOS 14 users. We keep one canonical arm64 wheel from macos-14 (works on macOS 14+) and use macos-15 purely for build-system coverage.

## Test plan
- [ ] CI: matrices grow to \`[macos-14, macos-15]\` on PR #99.
- [ ] Python build summary lists "macOS 14 + macOS 15 (Apple Silicon)".