### PR TITLE
Slim install: viser as [viz] extra + add quickstart demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,39 @@ ______________________________________________________________________
 
 ### Python
 
-The prerequisites for Pybind11 are just the minimum requirements as follows:"
+Install from PyPI (Linux x86_64 manylinux_2_28+, macOS 14+ arm64; sdist build elsewhere):
 
-```
-pip3 install --upgrade pip setuptools wheel scikit-build-core ninja cmake build
+```bash
+pip install kiss-matcher           # core only (numpy)
+pip install kiss-matcher[viz]      # adds viser for the visualization demo
 ```
 
-And then, run the following command:
+Or install editably from a source checkout:
 
+```bash
+pip install --upgrade pip setuptools wheel scikit-build-core ninja cmake build
+pip install -e python/
 ```
-pip3 install -e python/
+
+#### Quickstart
+
+After installing, run the synthetic-data smoke test (no external data, no viser):
+
+```bash
+python python/examples/quickstart.py
+```
+
+It generates 5k random points, applies a known rigid transform, and prints the
+recovered rotation/translation errors. Expect sub-degree rotation error and
+sub-centimetre translation error.
+
+For real point clouds with 3D visualization (requires `[viz]` extra):
+
+```bash
+python python/examples/run_kiss_matcher.py \
+    --src_path /path/to/src.pcd \
+    --tgt_path /path/to/tgt.pcd \
+    --resolution 0.3
 ```
 
 We also provide out-of-the-box python registration examples. Go to [**python**](https://github.com/MIT-SPARK/KISS-Matcher/tree/main/python) directory and follow the instructions.

--- a/python/examples/quickstart.py
+++ b/python/examples/quickstart.py
@@ -1,0 +1,60 @@
+"""Minimal end-to-end smoke test for KISS-Matcher.
+
+Generates a synthetic source point cloud, applies a known rigid transform
+to produce the target, and recovers the transform with KISS-Matcher.
+No external data files, no visualization deps — just numpy + kiss_matcher.
+
+Run after `pip install kiss-matcher`:
+
+    python -m kiss_matcher.examples.quickstart        # if examples are packaged
+    python python/examples/quickstart.py              # from a source checkout
+"""
+import numpy as np
+
+import kiss_matcher as km
+
+
+def make_random_rotation(rng: np.random.Generator) -> np.ndarray:
+    """Uniform random 3x3 rotation matrix via QR decomposition."""
+    q, r = np.linalg.qr(rng.standard_normal((3, 3)))
+    q = q @ np.diag(np.sign(np.diag(r)))
+    if np.linalg.det(q) < 0:
+        q[:, 0] *= -1
+    return q
+
+
+def main() -> None:
+    rng = np.random.default_rng(seed=42)
+
+    # Synthetic source: 5k points scattered in a 10 m cube.
+    src = rng.uniform(-5.0, 5.0, size=(5000, 3)).astype(np.float32)
+
+    # Known ground-truth rigid transform.
+    R_gt = make_random_rotation(rng).astype(np.float32)
+    t_gt = np.array([1.5, -0.7, 0.4], dtype=np.float32)
+    tgt = (R_gt @ src.T).T + t_gt
+
+    # Estimate the transform.
+    voxel_size = 0.3  # metres; tune to your sensor's point spacing
+    config = km.KISSMatcherConfig(voxel_size)
+    matcher = km.KISSMatcher(config)
+    result = matcher.estimate(src, tgt)
+
+    R_est = np.asarray(result.rotation)
+    t_est = np.asarray(result.translation)
+    rot_err_deg = np.degrees(np.arccos(np.clip((np.trace(R_gt.T @ R_est) - 1) / 2, -1.0, 1.0)))
+    trans_err = np.linalg.norm(t_est - t_gt)
+
+    print(f"# source points          : {src.shape[0]}")
+    print(f"# rotation inliers       : {matcher.get_num_rotation_inliers()}")
+    print(f"# final inliers          : {matcher.get_num_final_inliers()}")
+    print(f"rotation error (deg)     : {rot_err_deg:.3f}")
+    print(f"translation error (m)    : {trans_err:.4f}")
+
+    if matcher.get_num_final_inliers() < 5:
+        raise SystemExit("registration likely failed — try a smaller voxel_size")
+    print("\nKISS-Matcher recovered the transform.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,8 +32,14 @@ classifiers = [
 
 dependencies = [
   "numpy",
-  "viser",
 ]
+
+[project.optional-dependencies]
+# `viser` is only used by examples/run_kiss_matcher.py for 3D visualization.
+# It pulls in trimesh, scipy, networkx, shapely, embreex, etc. — heavy and
+# unnecessary for the core registration API. Install with the `viz` extra
+# when running the visualization demo: `pip install kiss-matcher[viz]`.
+viz = ["viser"]
 
 [tool.scikit-build]
 wheel.packages = ["kiss_matcher"]


### PR DESCRIPTION
## Summary
The default \`pip install kiss-matcher\` pulled in **viser**, which transitively dragged in trimesh, scipy, networkx, shapely, embreex, jsonschema, httpx, anyio, and ~20 other packages. None of those are used by the core registration library — only by \`examples/run_kiss_matcher.py\` for 3D visualization.

This PR:

1. **Moves \`viser\` to \`[project.optional-dependencies].viz\`.** Default install becomes just \`numpy\`. Users who want the visualization demo install with \`pip install kiss-matcher[viz]\`.
2. **Adds \`python/examples/quickstart.py\`** — a self-contained synthetic demo (random source cloud + known rigid transform → recovered transform) that needs no external data and no viser. Verified locally: 0.022° rotation error, 1 mm translation error on 5k points.
3. **Documents both paths in README** with the appropriate install commands.

## Verification

\`\`\`bash
$ python3 python/examples/quickstart.py
# source points          : 5000
# rotation inliers       : 703
# final inliers          : 702
rotation error (deg)     : 0.022
translation error (m)    : 0.0010

KISS-Matcher recovered the transform.
\`\`\`

## Impact on existing users
- \`pip install kiss-matcher\` is now ~30+ packages lighter.
- Anyone who relied on viser via a transitive install needs to switch to \`pip install kiss-matcher[viz]\` (a one-line change).

## Test plan
- [x] quickstart.py runs locally with sub-degree rotation error.
- [ ] CI: regular C++/Python builds still green (no functional change to the package itself).