### PR TITLE
Release v1.0.1 (slim install footprint)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "kiss_matcher"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">=3.8"
 description ='Python binding for KISS-Matcher'
 authors = [


### PR DESCRIPTION
Bumps the package version from 1.0.0 to 1.0.1 so the [viz]-extra split from #101 actually reaches PyPI users. No code changes.