### PR TITLE
v1.0.2: derive __version__ from package metadata

### DIFF
--- a/python/kiss_matcher/__init__.py
+++ b/python/kiss_matcher/__init__.py
@@ -27,7 +27,14 @@ simply::
     cfg = km.KISSMatcherConfig(voxel_size=0.3)
 """
 from importlib import import_module as _im
-__version__ = "1.0.0"
+from importlib.metadata import PackageNotFoundError as _PNF, version as _v
+
+try:
+    __version__ = _v("kiss_matcher")
+except _PNF:
+    __version__ = "0.0.0+unknown"
+
+del _PNF, _v
 __all__ = []
 # Import the backend that CMake just built (“_kiss_matcher” lives inside
 # the same package directory thanks to the change above).

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "kiss_matcher"
-version = "1.0.1"
+version = "1.0.2"
 requires-python = ">=3.8"
 description ='Python binding for KISS-Matcher'
 authors = [


### PR DESCRIPTION
## Summary
- Replaces the hardcoded \`__version__ = \"1.0.0\"\` in \`python/kiss_matcher/__init__.py\` with a dynamic lookup via \`importlib.metadata.version(\"kiss_matcher\")\`. Single source of truth (\`pyproject.toml\`); no more drift.
- Bumps the package version to 1.0.2 so PyPI users see the corrected runtime \`__version__\`.

## Why
On v1.0.1, \`pip install kiss-matcher\` reported \`Version: 1.0.1\` from \`pip show\` but \`python -c \"import kiss_matcher; print(kiss_matcher.__version__)\"\` returned \`1.0.0\` because \`__init__.py\` had it hardcoded. This drift is fixed by reading the actual installed metadata.

## Test plan
- [x] Local editable install reports \`__version__: 1.0.2\`.
- [ ] After merge + release, \`pip install kiss-matcher\` from PyPI reports \`1.0.2\` consistently from both \`pip show\` and \`kiss_matcher.__version__\`.